### PR TITLE
Typing interface fix

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,5 +1,5 @@
 export interface _VueStripeCheckout {
-  install: function;
+  install: (Vue: any, options?: any) => void
 }
 export declare const VueStripeCheckout: _VueStripeCheckout;
 export default VueStripeCheckout;


### PR DESCRIPTION
**Description:** This fixes a typescript type error `Cannot find name 'function'.`   If you're using the Vue CLI, the error doesn't directly affect the usage locally(everything works just fine), but the error stops production builds.  