### PR TITLE
add `args` to token callback

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -112,9 +112,9 @@ const VueStripeCheckout = {
               email: this.email,
               billingAddress: this.billingAddress,
               allowRememberMe: this.allowRememberMe,
-              token: token => {
-                this.$emit('done', token);
-                resolve(token);
+              token: (token, args) => {
+                this.$emit('done', token, args);
+                resolve(token, args);
               },
               opened: () => { this.$emit('opened') },
               closed: () => { this.$emit('closed') },


### PR DESCRIPTION
`args` is an object containing the billing and shipping addresses, if
enabled (https://stripe.com/docs/checkout#integration-simple-options)