### PR TITLE
Add a cancelled callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ Just see the [stripe docu](https://stripe.com/docs/checkout#integration-simple-o
       :allow-remember-me="false"
       @done="done"
       @opened="opened"
-      @closed="closed"
+      @closed="closed",
+      @canceled="canceled"
     ></vue-stripe-checkout>
     <button @click="checkout">Checkout</button>
   </div>
@@ -115,6 +116,9 @@ export default {
     },
     closed () {
       // do stuff 
+    },
+    canceled () {
+      // do stuff 
     }
   }
 }
@@ -144,6 +148,7 @@ See property description from official [Stripe Documentation](https://stripe.com
 - `done` - Emits an object containing the stripe `token` and `args` (an object containing the billing and shipping address if enabled).
 - `opened` - Called when the stripe checkout dialog has been opened.
 - `closed` - Called when the stripe checkout dialog has been closed.
+- `canceled` - Called when the stripe checkout dialog has been closed while cancelling.
 
 **Usage**
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ See property description from official [Stripe Documentation](https://stripe.com
   @done="done"
   @opened="opened"
   @closed="closed"
+  @canceled="canceled"
 ></vue-stripe-checkout>
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -78,6 +78,7 @@ const VueStripeCheckout = {
       },
       data: () => ({
         checkout: null,
+        doneEmitted: false
       }),
       computed: {
         key() {
@@ -113,11 +114,18 @@ const VueStripeCheckout = {
               billingAddress: this.billingAddress,
               allowRememberMe: this.allowRememberMe,
               token: (token, args) => {
+                this.doneEmitted = true;
                 this.$emit('done', {token, args});
                 resolve({token, args});
               },
               opened: () => { this.$emit('opened') },
-              closed: () => { this.$emit('closed') },
+              closed: () => { 
+                if (!this.doneEmitted) {
+                    this.$emit('canceled');
+                }
+                this.doneEmitted = false;
+                this.$emit('closed'); 
+              },
             };
             if (this.shippingAddress)
               Object.assign(options, {


### PR DESCRIPTION
Add a `cancelled` callback to allow making actions if the user closed the modal while cancelling.

Since stripe does not provides directly a callback for `canceled` we needed an other way around.

After investigating the actual comportement, I discovered that `done` is called before `closed` so that way I was able to use it with the `closed` callback to tell the operation was canceled.

Closes #39 