### PR TITLE
Adding an option to auto open the modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ See property description from official [Stripe Documentation](https://stripe.com
 - `shipping-address`: `Boolean`
 - `email`: `String`
 - `allow-remember-me`: `Boolean`
+- `auto-open-modal`: `Boolean`
 
 ### Events
 

--- a/src/index.js
+++ b/src/index.js
@@ -55,6 +55,10 @@ const VueStripeCheckout = {
           type: Boolean,
           default: true,
         },
+        autoOpenModal: {
+          type: Boolean,
+          default: false,
+        },
       },
       mounted() {
         if (document.querySelector('script#_stripe-checkout-script')) {
@@ -92,6 +96,7 @@ const VueStripeCheckout = {
           );
           if (stripeApp) stripeApp.remove();
           this.checkout = StripeCheckout.configure({ key: this.key });
+          if (this.autoOpenModal) this.open();
         },
         open() {
           if (!this.key) {


### PR DESCRIPTION
This PR is adding an option to auto open the modal. 

Since the component is loading in asynchronously which is normal since the loading of the stripe script, before this PR we actually need to add a setTimeout() to make sure the component is already loaded in case we wanted to open the modal at the creation of a component. Otherwise there was an error telling that checkout is undefined.

Now, with this new props, we have the possibility to ask the modal to open as soon as the component is loaded.