### PR TITLE
Updates component naming scheme

### DIFF
--- a/build/vue-stripe-checkout.js
+++ b/build/vue-stripe-checkout.js
@@ -6,7 +6,7 @@
 
 const VueStripeCheckout = {
   install(Vue, key) {
-    Vue.component('vue-stripe-checkout', {
+    Vue.component('VueStripeCheckout', {
       render: h => h('div', { style: { display: 'none' } }),
       props: {
         publishableKey: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -76,7 +76,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 var VueStripeCheckout = {
   install: function install(Vue, _key) {
-    Vue.component('vue-stripe-checkout', {
+    Vue.component('VueStripeCheckout', {
       render: function render(h) {
         return h('div', { style: { display: 'none' } });
       },

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 const VueStripeCheckout = {
   install(Vue, key) {
-    Vue.component('vue-stripe-checkout', {
+    Vue.component('VueStripeCheckout', {
       render: h => h('div', { style: { display: 'none' } }),
       props: {
         publishableKey: {


### PR DESCRIPTION
Due to the casing of the component name given to `Vue.component`, the component can only be used in templates as `<vue-stripe-checkout>`, and never `<VueStripCheckout>`.
Changing the casing allows both `<vue-stripe-checkout>` and `<VueStripCheckout>` to be used in templates.