### PR TITLE
Allow user to pass in extra data on createToken

### DIFF
--- a/src/elements/Card.vue
+++ b/src/elements/Card.vue
@@ -48,6 +48,10 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    tokenData: {
+      type: Object,
+      default: () => ({}),
+    },
     disableAdvancedFraudDetection: {
       type: Boolean,
     },
@@ -140,7 +144,7 @@ export default {
           ...this.element,
         };
         if (this.amount) data.amount = this.amount;
-        const { token, error } = await this.stripe.createToken(data);
+        const { token, error } = await this.stripe.createToken(data, tokenData);
         if (error) {
           const errorElement = document.getElementById('stripe-element-errors');
           errorElement.textContent = error.message;


### PR DESCRIPTION
Stripe docs highly recommend you pass in name and country:  https://stripe.com/docs/js/tokens_sources/create_token?type=cardElement

This allows the user to pass in that data, as well as any other data required for Radar