### PR TITLE
ci: add PR CI gate (lint, type-check, test, build, docs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Lint, type-check, test, build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm --filter @vue-stripe/vue-stripe lint
+
+      - name: Type-check
+        run: pnpm --filter @vue-stripe/vue-stripe type-check
+
+      - name: Test (coverage thresholds + doc-contract)
+        run: pnpm --filter @vue-stripe/vue-stripe test:coverage
+
+      - name: Build package
+        run: pnpm --filter @vue-stripe/vue-stripe build
+
+      - name: Build docs (VitePress)
+        run: pnpm --filter @vue-stripe/docs build


### PR DESCRIPTION
Adds a CI workflow that runs on every pull request and on pushes to `main`, closing the gap where there was no automated gate before merge (the v5.4.0 release relied on local verification only).

Runs the full verification gauntlet for `@vue-stripe/vue-stripe`:
- `lint`
- `type-check` (vue-tsc)
- `test:coverage` (enforces coverage thresholds + the strict doc/API contract test)
- package `build`
- VitePress `docs` build (also covers #422 — catches broken examples/components)

This PR validates itself: the new workflow runs on this PR.

Part of milestone **v5.4 DX, CI & Tooling**. Addresses #422.