### PR TITLE
docs: Stripe.js coverage tracker on the home page

### DIFF
--- a/apps/docs/.vitepress/theme/components/StripeCoverage.vue
+++ b/apps/docs/.vitepress/theme/components/StripeCoverage.vue
@@ -1,0 +1,257 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { coverage, type CoverageStatus } from '../data/stripe-coverage'
+
+const all = computed(() => coverage.flatMap((c) => c.items))
+
+const count = (s: CoverageStatus) => all.value.filter((i) => i.status === s).length
+
+const stats = computed(() => {
+  const covered = count('covered')
+  const accessible = count('accessible')
+  const planned = count('planned')
+  const deprecated = count('deprecated')
+  const total = covered + accessible + planned // exclude deprecated from the denominator
+  return {
+    covered,
+    accessible,
+    planned,
+    deprecated,
+    total,
+    coveredPct: total ? Math.round((covered / total) * 100) : 0,
+    reachablePct: total ? Math.round(((covered + accessible) / total) * 100) : 0
+  }
+})
+
+const META: Record<CoverageStatus, { label: string; icon: string; cls: string }> = {
+  covered: { label: 'Covered', icon: '✓', cls: 'is-covered' },
+  accessible: { label: 'Via raw API', icon: '◐', cls: 'is-accessible' },
+  planned: { label: 'Planned', icon: '○', cls: 'is-planned' },
+  deprecated: { label: 'Deprecated', icon: '—', cls: 'is-deprecated' }
+}
+
+const issueUrl = (n?: number) =>
+  n ? `https://github.com/vue-stripe/vue-stripe/issues/${n}` : undefined
+</script>
+
+<template>
+  <div class="coverage">
+    <div class="coverage-summary">
+      <div class="coverage-headline">
+        <span class="coverage-fraction">{{ stats.covered }}<span class="coverage-of">/{{ stats.total }}</span></span>
+        <span class="coverage-caption">Stripe.js elements &amp; features wrapped in dedicated Vue components</span>
+      </div>
+
+      <div class="coverage-bar" role="img" :aria-label="`${stats.coveredPct}% covered, ${stats.reachablePct}% reachable`">
+        <div class="coverage-bar-fill is-covered" :style="{ width: stats.coveredPct + '%' }" />
+        <div
+          class="coverage-bar-fill is-accessible"
+          :style="{ width: (stats.reachablePct - stats.coveredPct) + '%' }"
+        />
+      </div>
+
+      <div class="coverage-legend">
+        <span class="coverage-chip is-covered">{{ META.covered.icon }} {{ stats.covered }} Covered</span>
+        <span class="coverage-chip is-accessible">{{ META.accessible.icon }} {{ stats.accessible }} Via raw API</span>
+        <span class="coverage-chip is-planned">{{ META.planned.icon }} {{ stats.planned }} Planned</span>
+        <span class="coverage-chip is-deprecated">{{ META.deprecated.icon }} {{ stats.deprecated }} Deprecated</span>
+      </div>
+
+      <p class="coverage-note">
+        <strong>{{ stats.coveredPct }}%</strong> have a dedicated wrapper, and
+        <strong>{{ stats.reachablePct }}%</strong> are reachable today — anything not wrapped is still
+        available through the raw <code>stripe</code> / <code>elements</code> instance from
+        <code>useStripe()</code>.
+      </p>
+    </div>
+
+    <div class="coverage-groups">
+      <section v-for="cat in coverage" :key="cat.group" class="coverage-group">
+        <h4 class="coverage-group-title">{{ cat.group }}</h4>
+        <ul class="coverage-items">
+          <li v-for="item in cat.items" :key="item.name" :class="['coverage-item', META[item.status].cls]">
+            <span class="coverage-item-icon">{{ META[item.status].icon }}</span>
+            <span class="coverage-item-name">
+              <component
+                :is="issueUrl(item.issue) ? 'a' : 'span'"
+                :href="issueUrl(item.issue)"
+                :target="item.issue ? '_blank' : undefined"
+                rel="noopener noreferrer"
+              >{{ item.name }}</component>
+            </span>
+            <code class="coverage-item-api">{{ item.api }}</code>
+          </li>
+        </ul>
+      </section>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.coverage {
+  margin: 24px 0;
+}
+
+.coverage-summary {
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 12px;
+  padding: 24px;
+  background: var(--vp-c-bg-soft);
+}
+
+.coverage-headline {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 6px 14px;
+  margin-bottom: 16px;
+}
+
+.coverage-fraction {
+  font-size: 40px;
+  font-weight: 800;
+  line-height: 1;
+  color: var(--vp-c-brand-1);
+}
+
+.coverage-of {
+  color: var(--vp-c-text-3);
+  font-weight: 600;
+}
+
+.coverage-caption {
+  color: var(--vp-c-text-2);
+  font-size: 14px;
+  max-width: 460px;
+}
+
+.coverage-bar {
+  display: flex;
+  height: 12px;
+  border-radius: 999px;
+  overflow: hidden;
+  background: var(--vp-c-default-soft);
+}
+
+.coverage-bar-fill {
+  height: 100%;
+  transition: width 0.4s ease;
+}
+
+.coverage-bar-fill.is-covered {
+  background: var(--vp-c-brand-1);
+}
+
+.coverage-bar-fill.is-accessible {
+  background: var(--vp-c-brand-soft);
+}
+
+.coverage-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.coverage-chip {
+  font-size: 12.5px;
+  font-weight: 600;
+  padding: 3px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--vp-c-divider);
+  color: var(--vp-c-text-2);
+  white-space: nowrap;
+}
+
+.coverage-chip.is-covered {
+  color: var(--vp-c-brand-1);
+  border-color: var(--vp-c-brand-1);
+  background: var(--vp-c-brand-soft);
+}
+
+.coverage-chip.is-planned {
+  color: #b7791f;
+}
+
+.coverage-note {
+  margin: 14px 0 0;
+  font-size: 13.5px;
+  color: var(--vp-c-text-2);
+  line-height: 1.6;
+}
+
+.coverage-groups {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 18px;
+  margin-top: 24px;
+}
+
+.coverage-group-title {
+  margin: 0 0 8px;
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--vp-c-text-3);
+  border: none;
+}
+
+.coverage-items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.coverage-item {
+  display: grid;
+  grid-template-columns: 18px 1fr auto;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 0;
+  font-size: 13.5px;
+}
+
+.coverage-item-icon {
+  text-align: center;
+  font-weight: 700;
+  color: var(--vp-c-text-3);
+}
+
+.coverage-item.is-covered .coverage-item-icon {
+  color: var(--vp-c-brand-1);
+}
+
+.coverage-item.is-planned .coverage-item-icon {
+  color: #b7791f;
+}
+
+.coverage-item.is-deprecated {
+  opacity: 0.55;
+}
+
+.coverage-item-name {
+  color: var(--vp-c-text-1);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.coverage-item.is-deprecated .coverage-item-name {
+  text-decoration: line-through;
+}
+
+.coverage-item-name a {
+  color: inherit;
+  text-decoration: underline dotted;
+}
+
+.coverage-item-api {
+  font-size: 11px;
+  color: var(--vp-c-text-3);
+  background: transparent;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 130px;
+}
+</style>

--- a/apps/docs/.vitepress/theme/data/stripe-coverage.ts
+++ b/apps/docs/.vitepress/theme/data/stripe-coverage.ts
@@ -1,0 +1,138 @@
+// Stripe.js feature coverage matrix for Vue Stripe.
+//
+// This is the single source of truth for the home-page coverage tracker.
+// A guard test (packages/vue-stripe/tests/coverage-matrix.test.ts) verifies that
+// every `covered` entry's `artifact` is a real export of @vue-stripe/vue-stripe,
+// so the numbers here cannot drift above what actually ships.
+//
+// status:
+//   covered    – a dedicated Vue component or composable wraps it
+//   accessible – no wrapper, but reachable via the raw stripe / elements instance
+//                (useStripe().stripe / useStripeElements().elements)
+//   planned    – on the roadmap (issue linked)
+//   deprecated – deprecated by Stripe; intentionally not wrapped
+
+export type CoverageStatus = 'covered' | 'accessible' | 'planned' | 'deprecated'
+
+export interface CoverageItem {
+  name: string
+  /** Stripe.js API surface, e.g. elements.create('payment') or stripe.confirmPayment() */
+  api: string
+  status: CoverageStatus
+  /** Vue Stripe export that covers it (required when status === 'covered'). */
+  artifact?: string
+  /** Roadmap issue number (when status === 'planned'). */
+  issue?: number
+}
+
+export interface CoverageCategory {
+  group: string
+  items: CoverageItem[]
+}
+
+export const coverage: CoverageCategory[] = [
+  {
+    group: 'Core',
+    items: [
+      { name: 'Stripe Provider', api: 'loadStripe()', status: 'covered', artifact: 'VueStripeProvider' },
+      { name: 'Plugin', api: 'createVueStripe()', status: 'covered', artifact: 'createVueStripe' },
+      { name: 'Elements group', api: 'stripe.elements()', status: 'covered', artifact: 'VueStripeElements' },
+      { name: 'useStripe', api: 'Stripe instance', status: 'covered', artifact: 'useStripe' },
+      { name: 'useStripeElements', api: 'elements + submit()', status: 'covered', artifact: 'useStripeElements' }
+    ]
+  },
+  {
+    group: 'Payment Elements',
+    items: [
+      { name: 'Payment Element', api: "create('payment')", status: 'covered', artifact: 'VueStripePaymentElement' },
+      { name: 'Express Checkout Element', api: "create('expressCheckout')", status: 'covered', artifact: 'VueStripeExpressCheckoutElement' },
+      { name: 'Payment Request Button', api: "create('paymentRequestButton')", status: 'accessible' }
+    ]
+  },
+  {
+    group: 'Card Elements',
+    items: [
+      { name: 'Card Element', api: "create('card')", status: 'covered', artifact: 'VueStripeCardElement' },
+      { name: 'Card Number', api: "create('cardNumber')", status: 'covered', artifact: 'VueStripeCardNumberElement' },
+      { name: 'Card Expiry', api: "create('cardExpiry')", status: 'covered', artifact: 'VueStripeCardExpiryElement' },
+      { name: 'Card CVC', api: "create('cardCvc')", status: 'covered', artifact: 'VueStripeCardCvcElement' }
+    ]
+  },
+  {
+    group: 'Bank & Regional Elements',
+    items: [
+      { name: 'IBAN Element', api: "create('iban')", status: 'covered', artifact: 'VueStripeIbanElement' },
+      { name: 'iDEAL Bank', api: "create('idealBank')", status: 'covered', artifact: 'VueStripeIdealBankElement' },
+      { name: 'P24 Bank', api: "create('p24Bank')", status: 'covered', artifact: 'VueStripeP24BankElement' },
+      { name: 'EPS Bank', api: "create('epsBank')", status: 'covered', artifact: 'VueStripeEpsBankElement' },
+      { name: 'FPX Bank', api: "create('fpxBank')", status: 'accessible' },
+      { name: 'AU Bank Account', api: "create('auBankAccount')", status: 'accessible' }
+    ]
+  },
+  {
+    group: 'Address & Link',
+    items: [
+      { name: 'Address Element', api: "create('address')", status: 'covered', artifact: 'VueStripeAddressElement' },
+      { name: 'Link Authentication', api: "create('linkAuthentication')", status: 'covered', artifact: 'VueStripeLinkAuthenticationElement' },
+      { name: 'Shipping Address', api: "create('shippingAddress')", status: 'deprecated' }
+    ]
+  },
+  {
+    group: 'Messaging Elements',
+    items: [
+      { name: 'Payment Method Messaging', api: "create('paymentMethodMessaging')", status: 'planned', issue: 378 },
+      { name: 'Affirm Message', api: "create('affirmMessage')", status: 'accessible' },
+      { name: 'Afterpay/Clearpay Message', api: "create('afterpayClearpayMessage')", status: 'accessible' }
+    ]
+  },
+  {
+    group: 'Other Elements',
+    items: [
+      { name: 'Currency Selector', api: "create('currencySelector')", status: 'planned', issue: 382 },
+      { name: 'Tax ID', api: "create('taxId')", status: 'planned', issue: 383 }
+    ]
+  },
+  {
+    group: 'Issuing Elements',
+    items: [
+      { name: 'Card Number Display', api: "create('issuingCardNumberDisplay')", status: 'accessible' },
+      { name: 'Card CVC Display', api: "create('issuingCardCvcDisplay')", status: 'accessible' },
+      { name: 'Card Expiry Display', api: "create('issuingCardExpiryDisplay')", status: 'accessible' },
+      { name: 'Card PIN Display', api: "create('issuingCardPinDisplay')", status: 'accessible' },
+      { name: 'Card Copy Button', api: "create('issuingCardCopyButton')", status: 'accessible' }
+    ]
+  },
+  {
+    group: 'Checkout',
+    items: [
+      { name: 'Redirect to Checkout', api: 'stripe.redirectToCheckout()', status: 'covered', artifact: 'VueStripeCheckout' },
+      { name: 'Checkout composable', api: 'redirect helpers', status: 'covered', artifact: 'useStripeCheckout' },
+      { name: 'Pricing Table', api: '<stripe-pricing-table>', status: 'covered', artifact: 'VueStripePricingTable' },
+      { name: 'Embedded Checkout', api: 'stripe.initEmbeddedCheckout()', status: 'planned', issue: 379 },
+      { name: 'Custom Checkout', api: 'stripe.initCheckout()', status: 'planned', issue: 388 }
+    ]
+  },
+  {
+    group: 'Payments & Setup',
+    items: [
+      { name: 'Confirm Payment', api: 'stripe.confirmPayment()', status: 'covered', artifact: 'usePaymentIntent' },
+      { name: 'Confirm Setup', api: 'stripe.confirmSetup()', status: 'covered', artifact: 'useSetupIntent' },
+      { name: 'Create Payment Method', api: 'stripe.createPaymentMethod()', status: 'planned', issue: 390 },
+      { name: 'Handle Next Action', api: 'stripe.handleNextAction()', status: 'planned', issue: 390 },
+      { name: 'Retrieve Payment Intent', api: 'stripe.retrievePaymentIntent()', status: 'planned', issue: 390 },
+      { name: 'Retrieve Setup Intent', api: 'stripe.retrieveSetupIntent()', status: 'planned', issue: 390 },
+      { name: 'Confirm Card Payment', api: 'stripe.confirmCardPayment()', status: 'accessible' },
+      { name: 'Confirm Card Setup', api: 'stripe.confirmCardSetup()', status: 'accessible' },
+      { name: 'Create Token', api: 'stripe.createToken()', status: 'accessible' },
+      { name: 'Create Confirmation Token', api: 'stripe.createConfirmationToken()', status: 'accessible' }
+    ]
+  },
+  {
+    group: 'Advanced',
+    items: [
+      { name: 'Financial Connections', api: 'stripe.collectFinancialConnectionsAccounts()', status: 'planned', issue: 393 },
+      { name: 'Identity Verification', api: 'stripe.verifyIdentity()', status: 'planned', issue: 393 },
+      { name: 'Bank Account Collection', api: 'stripe.collectBankAccountForPayment()', status: 'accessible' }
+    ]
+  }
+]

--- a/apps/docs/.vitepress/theme/index.ts
+++ b/apps/docs/.vitepress/theme/index.ts
@@ -7,6 +7,7 @@ import './styles/vars.css'
 import StripeBadge from './components/StripeBadge.vue'
 import CopyForLLM from './components/CopyForLLM.vue'
 import GitHubStarsCTA from './components/GitHubStarsCTA.vue'
+import StripeCoverage from './components/StripeCoverage.vue'
 
 // Example components for interactive documentation
 import ProductSelector from './components/examples/ProductSelector.vue'
@@ -96,5 +97,6 @@ export default {
     app.component('CardElementExample', CardElementExample)
     app.component('SplitCardElementExample', SplitCardElementExample)
     app.component('LinkAuthenticationExample', LinkAuthenticationExample)
+    app.component('StripeCoverage', StripeCoverage)
   }
 } satisfies Theme

--- a/apps/docs/index.md
+++ b/apps/docs/index.md
@@ -107,4 +107,10 @@ async function confirmPayment() {
 This is a live demo using Stripe's test mode. Use card number `4242 4242 4242 4242` with any future date and CVC.
 :::
 
+## Stripe.js Coverage
+
+How much of Stripe.js does Vue Stripe wrap? This tracker compares our components and composables against Stripe.js elements, checkout flows, and payment methods — so you can see at a glance what ships today. Anything not yet wrapped is still reachable through the raw `stripe` / `elements` instance, and the list grows as new features land.
+
+<StripeCoverage />
+
 </div>

--- a/packages/vue-stripe/tests/coverage-matrix.test.ts
+++ b/packages/vue-stripe/tests/coverage-matrix.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import * as VueStripe from '../src'
+import { coverage } from '../../../apps/docs/.vitepress/theme/data/stripe-coverage'
+
+/**
+ * Guards the home-page Stripe.js coverage tracker
+ * (apps/docs/.vitepress/theme/data/stripe-coverage.ts) against drift: anything
+ * marked `covered` must name a real export of @vue-stripe/vue-stripe, so the
+ * headline number can never claim more than actually ships.
+ */
+describe('docs coverage matrix', () => {
+  const exportNames = new Set(Object.keys(VueStripe))
+  const items = coverage.flatMap((c) => c.items)
+
+  it('every "covered" entry names a real package export', () => {
+    for (const item of items.filter((i) => i.status === 'covered')) {
+      expect(item.artifact, `"${item.name}" is covered but has no artifact`).toBeTruthy()
+      expect(
+        exportNames.has(item.artifact!),
+        `"${item.name}" claims export "${item.artifact}" which is not exported from @vue-stripe/vue-stripe`
+      ).toBe(true)
+    }
+  })
+
+  it('planned entries link a roadmap issue; only covered entries carry an artifact', () => {
+    for (const item of items) {
+      if (item.status === 'planned') {
+        expect(typeof item.issue, `"${item.name}" is planned but has no issue number`).toBe('number')
+      }
+      if (item.status !== 'covered') {
+        expect(item.artifact, `"${item.name}" is ${item.status} but names an artifact`).toBeUndefined()
+      }
+    }
+  })
+})


### PR DESCRIPTION
Adds a **Stripe.js coverage tracker** to the docs home page so visitors (and we) can see at a glance how much of Stripe.js Vue Stripe wraps.

- **Full feature matrix** — elements, checkout flows, payment/setup methods, and advanced APIs — grouped into 11 categories.
- **Headline**: progress bar + `22 / 48` wrapped (**46%** have a dedicated wrapper, **77%** reachable today). Anything not wrapped is still available via the raw `stripe`/`elements` instance.
- **Single source of truth** (`apps/docs/.vitepress/theme/data/stripe-coverage.ts`) with statuses: covered / via-raw-API / planned / deprecated. Planned items link their roadmap issue.
- **Drift-proof**: a guard test (`tests/coverage-matrix.test.ts`) fails CI if any `covered` entry doesn't map to a real package export — so the number can never overstate what ships.

Doubles as the living version of the audit's feature-coverage report (#394). Ticks up automatically as #378/#382/#383/#390 land.

Verified: 271 tests pass, VitePress build passes, and the widget was rendered + number-checked in a real browser.