### PR TITLE
docs: move coverage tracker to /coverage page with count in nav

### DIFF
--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -1,5 +1,13 @@
 import { defineConfig, loadEnv } from 'vitepress'
 import { buildEndGenerateOpenGraphImages } from '@nolebase/vitepress-plugin-og-image/vitepress'
+import { coverage } from './theme/data/stripe-coverage'
+
+// Build the "Coverage xx/xx" nav label from the single coverage data source,
+// so the toolbar count stays in sync with the /coverage page automatically.
+const coverageItems = coverage.flatMap((c) => c.items)
+const coveredCount = coverageItems.filter((i) => i.status === 'covered').length
+const trackableCount = coverageItems.filter((i) => i.status !== 'deprecated').length
+const coverageNavLabel = `Coverage ${coveredCount}/${trackableCount}`
 
 // Load environment variables from .env files (for local dev)
 const envFromFile = loadEnv('', process.cwd())
@@ -103,6 +111,7 @@ if (window.location.hostname === 'localhost' || window.location.hostname === '12
       { text: 'Guide', link: '/guide/introduction' },
       { text: 'API', link: '/api/' },
       { text: 'Live Demo', link: '/live-demo/' },
+      { text: coverageNavLabel, link: '/coverage' },
       {
         text: 'Links',
         items: [

--- a/apps/docs/coverage.md
+++ b/apps/docs/coverage.md
@@ -1,0 +1,12 @@
+---
+title: Stripe.js Coverage
+description: How much of Stripe.js Vue Stripe wraps — elements, checkout flows, and payment/setup methods.
+---
+
+# Stripe.js Coverage
+
+How much of Stripe.js does Vue Stripe wrap? This page compares our components and composables against Stripe.js elements, checkout flows, and payment/setup methods, so you can see at a glance what ships today.
+
+Anything not yet wrapped is still reachable through the raw `stripe` / `elements` instance returned by `useStripe()` and `useStripeElements()` — and the list grows as new features land.
+
+<StripeCoverage />

--- a/apps/docs/index.md
+++ b/apps/docs/index.md
@@ -107,10 +107,4 @@ async function confirmPayment() {
 This is a live demo using Stripe's test mode. Use card number `4242 4242 4242 4242` with any future date and CVC.
 :::
 
-## Stripe.js Coverage
-
-How much of Stripe.js does Vue Stripe wrap? This tracker compares our components and composables against Stripe.js elements, checkout flows, and payment methods — so you can see at a glance what ships today. Anything not yet wrapped is still reachable through the raw `stripe` / `elements` instance, and the list grows as new features land.
-
-<StripeCoverage />
-
 </div>


### PR DESCRIPTION
Moves the Stripe.js coverage widget off the home page onto a dedicated **/coverage** page, and adds a **"Coverage 22/48"** link to the toolbar. The count in the nav label is computed at build time from the same `stripe-coverage.ts` data source, so it never drifts from the page. Guard test + docs build keep it honest.