### PR TITLE
docs: make /coverage page full-width

### DIFF
--- a/apps/docs/.vitepress/theme/styles/vars.css
+++ b/apps/docs/.vitepress/theme/styles/vars.css
@@ -193,4 +193,18 @@
   --vp-button-brand-active-bg: #5046e5;
 }
 
+/* Full-width layout for the Stripe.js coverage page (pageClass: coverage-page).
+   Lifts VitePress's prose-width cap so the coverage grid uses the normal page
+   width instead of the narrow ~688px article column. !important is needed to
+   beat VitePress's equal-specificity :not(.has-sidebar) rules. */
+.coverage-page .VPDoc .container {
+  max-width: 1152px !important;
+}
+.coverage-page .VPDoc .content {
+  max-width: 100% !important;
+}
+.coverage-page .VPDoc .content-container {
+  max-width: 100% !important;
+}
+
 

--- a/apps/docs/coverage.md
+++ b/apps/docs/coverage.md
@@ -1,6 +1,8 @@
 ---
 title: Stripe.js Coverage
 description: How much of Stripe.js Vue Stripe wraps — elements, checkout flows, and payment/setup methods.
+aside: false
+pageClass: coverage-page
 ---
 
 # Stripe.js Coverage


### PR DESCRIPTION
The coverage grid was rendering in VitePress's narrow ~688px article column. Switch the page to full-width (aside:false + pageClass override) so it uses the normal page width — 3 columns instead of 2. Verified rendered width 688px → 1088px in a real browser.