### PR TITLE
ci: auto-create GitHub Release on tag publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   publish:
@@ -42,3 +42,9 @@ jobs:
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: gh release create "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --generate-notes --verify-tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
After publishing to npm, the workflow now also creates a **GitHub Release** for the tag (`gh release create --generate-notes`). This is why v5.4.0's Release had to be created by hand — `publish.yml` only pushed to npm.

- Adds a `Create GitHub Release` step (runs only on `v*` tags).
- Bumps workflow `permissions` to `contents: write` (needed to create releases).
- Uses the built-in `GITHUB_TOKEN`.

Not runtime-testable without an actual tag publish; the next release (e.g. 5.4.1/5.5.0) will exercise it.