### PR TITLE
feat(elements): appearance, fonts & locale as first-class props (#389)

### DIFF
--- a/apps/docs/api/components/stripe-elements.md
+++ b/apps/docs/api/components/stripe-elements.md
@@ -60,9 +60,22 @@ const clientSecret = 'pi_xxx_secret_xxx' // From your backend
 | `setupFutureUsage` | `'off_session' \| 'on_session'` | No | Indicates intent to save the payment method for future use |
 | `captureMethod` | `'automatic' \| 'automatic_async' \| 'manual'` | No | Controls when to capture funds from the customer's account |
 | `paymentMethodTypes` | `string[]` | No | List of payment method types to display. Omit to use Dashboard payment method settings |
+| `appearance` | `object` | No | [Appearance API](#appearance-api) options to theme all child elements (theme, variables, rules, labels). Convenience prop — equivalent to `options.appearance` |
+| `fonts` | `object[]` | No | Custom fonts to load into the Elements iframe (`CssFontSource` / `CustomFontSource`). Convenience prop — equivalent to `options.fonts` |
+| `locale` | `string` | No | Locale to display Elements in (e.g. `'en'`, `'fr'`, `'auto'`). Convenience prop — equivalent to `options.locale` |
 | `options` | `object` | No | Additional options passed to `stripe.elements()` |
 
 \* Required for Payment Element and some other elements. Optional for Card Element. When `clientSecret` is omitted, use `mode`/`currency`/`amount` for deferred intent creation.
+
+::: tip Convenience props vs. `options`
+`appearance`, `fonts`, and `locale` are first-class convenience props so you can bind them directly without nesting them inside `options`. If you set the same key in both `options` and a dedicated prop, the dedicated prop wins.
+
+```vue
+<!-- These two are equivalent -->
+<VueStripeElements :appearance="{ theme: 'night' }" />
+<VueStripeElements :options="{ appearance: { theme: 'night' } }" />
+```
+:::
 
 ### Options Object
 

--- a/apps/playground/src/views/StripeElementsView.vue
+++ b/apps/playground/src/views/StripeElementsView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, inject, defineComponent, h, computed } from 'vue'
-import { VueStripeProvider, VueStripeElements, useStripeElements } from '@vue-stripe/vue-stripe'
+import { VueStripeProvider, VueStripeElements, VueStripeCardElement, useStripeElements } from '@vue-stripe/vue-stripe'
 import {
   Card,
   CardHeader,
@@ -108,6 +108,19 @@ const darkAppearance = {
   variables: {
     colorPrimary: '#7c3aed'
   }
+}
+
+// Custom fonts demo (first-class `fonts` prop, #389)
+const customFonts = [
+  { cssSrc: 'https://fonts.googleapis.com/css?family=Roboto' }
+]
+
+// Tracks the themed Card element mounting successfully (proves first-class
+// appearance/fonts/locale props flow through to a real Stripe element).
+const appearanceCardReady = ref(false)
+const onAppearanceCardReady = () => {
+  appearanceCardReady.value = true
+  log('ready', 'Card element mounted with first-class appearance/fonts/locale props')
 }
 </script>
 
@@ -254,35 +267,46 @@ const darkAppearance = {
           </VueStripeProvider>
         </div>
 
-        <!-- Custom appearance -->
+        <!-- Custom appearance (first-class appearance/fonts/locale props, #389) -->
         <div v-else-if="testScenario === 'appearance'" class="bg-secondary rounded-lg p-6">
           <VueStripeProvider :publishable-key="stripeConfig.publishableKey">
             <VueStripeElements
-              :client-secret="cleanClientSecret"
-              :options="{ appearance: appearanceOptions }"
+              :appearance="appearanceOptions"
+              :fonts="customFonts"
+              locale="en"
             >
-              <div class="text-center py-8 bg-card rounded-lg shadow-sm">
+              <div class="text-center py-8 bg-card rounded-lg shadow-sm" data-test="appearance-scenario">
                 <span class="text-4xl mb-4 block">🎨</span>
-                <strong class="block text-lg mb-2">Custom Appearance</strong>
-                <p class="text-muted-foreground">Using the Stripe Appearance API for styling.</p>
+                <strong class="block text-lg mb-2">Custom Appearance (first-class props)</strong>
+                <p class="text-muted-foreground">
+                  Bound directly via <code class="bg-muted px-1 rounded">:appearance</code>,
+                  <code class="bg-muted px-1 rounded">:fonts</code> and
+                  <code class="bg-muted px-1 rounded">locale</code> props — no <code class="bg-muted px-1 rounded">:options</code> nesting.
+                </p>
+                <div class="max-w-md mx-auto mt-4 text-left">
+                  <VueStripeCardElement data-test="appearance-card" @ready="onAppearanceCardReady" />
+                </div>
+                <p
+                  v-if="appearanceCardReady"
+                  data-test="appearance-ready"
+                  class="mt-3 p-3 rounded-md text-sm bg-success/10 text-success"
+                >
+                  ✅ Themed Card element mounted with first-class props
+                </p>
                 <pre class="bg-secondary p-3 rounded-md text-xs text-left overflow-x-auto mt-3">{{ JSON.stringify(appearanceOptions, null, 2) }}</pre>
-                <component :is="ElementsConsumer" :client-secret="cleanClientSecret" />
               </div>
             </VueStripeElements>
           </VueStripeProvider>
         </div>
 
-        <!-- Dark theme -->
+        <!-- Dark theme (first-class appearance prop, #389) -->
         <div v-else-if="testScenario === 'dark-theme'" class="bg-slate-900 text-slate-100 rounded-lg p-6">
           <VueStripeProvider :publishable-key="stripeConfig.publishableKey">
-            <VueStripeElements
-              :client-secret="cleanClientSecret"
-              :options="{ appearance: darkAppearance }"
-            >
+            <VueStripeElements :appearance="darkAppearance">
               <div class="text-center py-8 bg-slate-800 rounded-lg shadow-sm">
                 <span class="text-4xl mb-4 block">🌙</span>
-                <strong class="block text-lg mb-2">Dark Theme</strong>
-                <p class="text-slate-400">Using <code class="bg-slate-700 px-1 rounded">theme: 'night'</code> with custom primary color.</p>
+                <strong class="block text-lg mb-2">Dark Theme (first-class prop)</strong>
+                <p class="text-slate-400">Bound via <code class="bg-slate-700 px-1 rounded">:appearance="{ theme: 'night' }"</code>.</p>
                 <component :is="ElementsConsumer" :client-secret="cleanClientSecret" />
               </div>
             </VueStripeElements>

--- a/packages/vue-stripe/src/components/VueStripeElements.vue
+++ b/packages/vue-stripe/src/components/VueStripeElements.vue
@@ -78,6 +78,19 @@ interface Props {
    */
   paymentMethodTypes?: string[] | undefined
   /**
+   * Appearance API options to theme the Elements (variables, rules, theme, labels).
+   * @see https://docs.stripe.com/elements/appearance-api
+   */
+  appearance?: Record<string, unknown> | undefined
+  /**
+   * Custom fonts to load into the Elements iframe (CssFontSource | CustomFontSource).
+   */
+  fonts?: Array<Record<string, unknown>> | undefined
+  /**
+   * Locale to display the Elements in (e.g. 'en', 'fr', 'auto').
+   */
+  locale?: string | undefined
+  /**
    * Additional options passed to stripe.elements().
    * See Stripe documentation for all available options.
    */
@@ -142,6 +155,17 @@ const createElements = () => {
       elementsOptions['paymentMethodTypes'] = props.paymentMethodTypes
     }
 
+    // First-class appearance / fonts / locale props
+    if (props.appearance) {
+      elementsOptions['appearance'] = props.appearance
+    }
+    if (props.fonts) {
+      elementsOptions['fonts'] = props.fonts
+    }
+    if (props.locale) {
+      elementsOptions['locale'] = props.locale
+    }
+
     // Use type assertion since Stripe has complex overloads
     elements.value = (stripeInstance.stripe.value as any).elements(elementsOptions)
     loading.value = false
@@ -188,6 +212,22 @@ watch(
       createElements()
     }
   }
+)
+
+// Watch appearance / locale changes — apply via elements.update() so child
+// elements keep their state instead of being destroyed and re-created.
+// (fonts can only be set at creation time, so they are not updated here.)
+watch(
+  () => [props.appearance, props.locale],
+  () => {
+    if (elements.value) {
+      const updateOptions: Record<string, unknown> = {}
+      if (props.appearance) updateOptions['appearance'] = props.appearance
+      if (props.locale) updateOptions['locale'] = props.locale
+      ;(elements.value as { update: (options: Record<string, unknown>) => void }).update(updateOptions)
+    }
+  },
+  { deep: true }
 )
 
 onMounted(() => {

--- a/packages/vue-stripe/src/types/index.ts
+++ b/packages/vue-stripe/src/types/index.ts
@@ -117,6 +117,19 @@ export interface VueStripeElementsProps {
    */
   paymentMethodTypes?: string[] | undefined
   /**
+   * Appearance API options to theme the Elements.
+   * @see https://docs.stripe.com/elements/appearance-api
+   */
+  appearance?: Record<string, unknown> | undefined
+  /**
+   * Custom fonts to load into the Elements iframe.
+   */
+  fonts?: Array<Record<string, unknown>> | undefined
+  /**
+   * Locale to display the Elements in (e.g. 'en', 'fr', 'auto').
+   */
+  locale?: string | undefined
+  /**
    * Additional options passed to stripe.elements().
    */
   options?: StripeElementsOptions | undefined

--- a/packages/vue-stripe/tests/components/VueStripeElements.test.ts
+++ b/packages/vue-stripe/tests/components/VueStripeElements.test.ts
@@ -151,6 +151,43 @@ describe('VueStripeElements', () => {
     })
   })
 
+  it('should pass appearance, fonts, and locale props to elements options', async () => {
+    const mockElements = vi.fn(() => ({
+      create: vi.fn(() => ({
+        mount: vi.fn(),
+        destroy: vi.fn(),
+        on: vi.fn()
+      }))
+    }))
+
+    const mockLoadStripe = vi.mocked(await import('@stripe/stripe-js')).loadStripe
+    mockLoadStripe.mockResolvedValueOnce({
+      elements: mockElements,
+      confirmPayment: vi.fn(),
+      confirmCardSetup: vi.fn(),
+      registerAppInfo: vi.fn()
+    } as any)
+
+    const appearance = { theme: 'night', variables: { colorPrimary: '#635bff' } }
+    const fonts = [{ cssSrc: 'https://fonts.googleapis.com/css?family=Roboto' }]
+
+    mountWithProvider({
+      clientSecret: 'pi_123_secret_456',
+      appearance,
+      fonts,
+      locale: 'fr'
+    })
+
+    await flushPromises()
+
+    expect(mockElements).toHaveBeenCalledWith({
+      clientSecret: 'pi_123_secret_456',
+      appearance,
+      fonts,
+      locale: 'fr'
+    })
+  })
+
   it('should provide elements context to child components', async () => {
     let injectedContext: ReturnType<typeof inject<any>> = null
 


### PR DESCRIPTION
## Summary

Closes #389. Adds `appearance`, `fonts` and `locale` as **first-class props** on `VueStripeElements`, so they can be bound directly instead of nested inside `options`.

```vue
<!-- before -->
<VueStripeElements :options="{ appearance: { theme: 'night' }, fonts, locale: 'fr' }" />

<!-- now (equivalent, also still supported via :options) -->
<VueStripeElements :appearance="{ theme: 'night' }" :fonts="fonts" locale="fr" />
```

## Changes

- **`VueStripeElements.vue`**: add `appearance` / `fonts` / `locale` props; merge them into the `stripe.elements()` options. Dedicated props are applied **after** the `options` spread, so a dedicated prop wins when both set the same key.
- A dedicated watcher applies `appearance`/`locale` changes at runtime via `elements.update()` (Stripe's recommended path) so child elements keep their state instead of being destroyed/re-created. `fonts` can only be set at creation time and is intentionally not live-updated.
- Mirror the props on the public `VueStripeElementsProps` type.
- Unit test asserting all three props flow into `stripe.elements({ ... })`.
- Document the convenience props (+ "dedicated prop wins" note) on the API page.
- Playground: convert the *Appearance* / *Dark Theme* scenarios to use the first-class props and mount a real themed Card element.

## Verification

- ✅ `pnpm build` (vite + tsc) clean
- ✅ Full package suite: **272 tests pass** (incl. new test)
- ✅ **Live Stripe test** (real `pk_test`, headless Chromium): switching to the Appearance scenario mounts a real Stripe Elements iframe (`js.stripe.com/v3/elements-inner-card-…`), `@ready` fires, **zero console errors** — confirming the first-class props reach a real Stripe element.

> Do not merge yet — opening for morning review per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)