### PR TITLE
fix(playground): stop hardcoding pk_test key in docs views (#428)

### DIFF
--- a/apps/playground/src/views/DocsExampleView.vue
+++ b/apps/playground/src/views/DocsExampleView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, computed, inject } from 'vue'
 import type { Stripe, StripeElements } from '@stripe/stripe-js'
 import {
   VueStripeProvider,
@@ -7,8 +7,10 @@ import {
   VueStripePaymentElement
 } from '@vue-stripe/vue-stripe'
 
-// Using test key provided by user
-const publishableKey = 'pk_test_51OIHqMIx2Vb66eaKneiRI89KWckP2FB7c75OLUZGezoXDiCHlIXMh6dBkTyWRe8oz77CO6B0udvWS6yWWdDaiwS800oW2Na8mk'
+// Publishable key comes from the shared playground config (set via the header
+// "Add Key" dialog / localStorage) — never hardcode a key in source.
+const stripeConfig = inject<{ publishableKey: string }>('stripeConfig')
+const publishableKey = computed(() => stripeConfig?.publishableKey ?? '')
 const clientSecret = ref('')
 const clientSecretInput = ref('')
 const loading = ref(false)
@@ -69,48 +71,55 @@ const handleSubmit = async () => {
     <h2>Docs Example Test</h2>
     <p class="description">Testing the single-file event-based pattern from the documentation.</p>
 
-    <!-- Client Secret Input -->
-    <div v-if="!clientSecret" class="secret-form">
-      <label for="secret">Client Secret (from PaymentIntent):</label>
-      <input
-        id="secret"
-        v-model="clientSecretInput"
-        type="text"
-        placeholder="pi_xxx_secret_xxx"
-      />
-      <button @click="setClientSecret" :disabled="!clientSecretInput.trim()">
-        Set Client Secret
-      </button>
-      <p class="hint">
-        Create a PaymentIntent in <a href="https://dashboard.stripe.com/test/payments" target="_blank">Stripe Dashboard</a> and paste the client_secret here.
-      </p>
+    <!-- No key configured -->
+    <div v-if="!publishableKey" class="error">
+      No Stripe publishable key configured. Click <strong>"Add Key"</strong> in the header to add a test key.
     </div>
 
-    <!-- Payment Form -->
-    <VueStripeProvider v-else :publishable-key="publishableKey" @load="onStripeLoad">
-      <VueStripeElements
-        v-if="clientSecret"
-        :client-secret="clientSecret"
-        @ready="onElementsReady"
-      >
-        <form @submit.prevent="handleSubmit">
-          <VueStripePaymentElement />
+    <template v-else>
+      <!-- Client Secret Input -->
+      <div v-if="!clientSecret" class="secret-form">
+        <label for="secret">Client Secret (from PaymentIntent):</label>
+        <input
+          id="secret"
+          v-model="clientSecretInput"
+          type="text"
+          placeholder="pi_xxx_secret_xxx"
+        />
+        <button @click="setClientSecret" :disabled="!clientSecretInput.trim()">
+          Set Client Secret
+        </button>
+        <p class="hint">
+          Create a PaymentIntent in <a href="https://dashboard.stripe.com/test/payments" target="_blank">Stripe Dashboard</a> and paste the client_secret here.
+        </p>
+      </div>
 
-          <div v-if="errorMessage" class="error">
-            {{ errorMessage }}
-          </div>
+      <!-- Payment Form -->
+      <VueStripeProvider v-else :publishable-key="publishableKey" @load="onStripeLoad">
+        <VueStripeElements
+          v-if="clientSecret"
+          :client-secret="clientSecret"
+          @ready="onElementsReady"
+        >
+          <form @submit.prevent="handleSubmit">
+            <VueStripePaymentElement />
 
-          <button type="submit" :disabled="loading">
-            {{ loading ? 'Processing...' : 'Pay Now' }}
-          </button>
-        </form>
-      </VueStripeElements>
+            <div v-if="errorMessage" class="error">
+              {{ errorMessage }}
+            </div>
 
-      <template v-else>
-        <div v-if="errorMessage" class="error">{{ errorMessage }}</div>
-        <p v-else>Loading payment form...</p>
-      </template>
-    </VueStripeProvider>
+            <button type="submit" :disabled="loading">
+              {{ loading ? 'Processing...' : 'Pay Now' }}
+            </button>
+          </form>
+        </VueStripeElements>
+
+        <template v-else>
+          <div v-if="errorMessage" class="error">{{ errorMessage }}</div>
+          <p v-else>Loading payment form...</p>
+        </template>
+      </VueStripeProvider>
+    </template>
 
     <!-- Debug Info -->
     <div class="debug">

--- a/apps/playground/src/views/DocsVerificationView.vue
+++ b/apps/playground/src/views/DocsVerificationView.vue
@@ -5,7 +5,7 @@
  * This component tests code examples directly from the documentation
  * to ensure they work correctly when users copy them.
  */
-import { ref } from 'vue'
+import { ref, computed, inject } from 'vue'
 import type { Stripe, StripeElements } from '@stripe/stripe-js'
 import {
   VueStripeProvider,
@@ -16,7 +16,10 @@ import {
   VueStripeExpressCheckoutElement
 } from '@vue-stripe/vue-stripe'
 
-const publishableKey = 'pk_test_51OIHqMIx2Vb66eaKneiRI89KWckP2FB7c75OLUZGezoXDiCHlIXMh6dBkTyWRe8oz77CO6B0udvWS6yWWdDaiwS800oW2Na8mk'
+// Publishable key comes from the shared playground config (set via the header
+// "Add Key" dialog / localStorage) — never hardcode a key in source.
+const stripeConfig = inject<{ publishableKey: string }>('stripeConfig')
+const publishableKey = computed(() => stripeConfig?.publishableKey ?? '')
 
 // Available test examples
 const examples = [
@@ -140,6 +143,11 @@ const addressOptions = {
   <div class="docs-verification">
     <h2>📚 Documentation Code Verification</h2>
     <p class="subtitle">Testing exact code examples from the documentation</p>
+
+    <!-- No key configured -->
+    <div v-if="!publishableKey" class="secret-input">
+      No Stripe publishable key configured. Click <strong>"Add Key"</strong> in the header to add a test key.
+    </div>
 
     <!-- Example Selector -->
     <div class="example-selector">


### PR DESCRIPTION
## Summary

Closes #428. `DocsExampleView.vue` and `DocsVerificationView.vue` embedded a **real `pk_test` publishable key** directly in source. They now inject the key from the shared playground `stripeConfig` (set via the header **Add Key** dialog / `localStorage`), matching every other playground view, and render a "no key configured" notice when none is set.

## Changes

- `inject<{ publishableKey: string }>('stripeConfig')` + `computed(() => stripeConfig?.publishableKey ?? '')` in both views.
- Removed the hardcoded `pk_test_51OIHqM…` literal.
- Added a "No Stripe publishable key configured — click Add Key" banner; the form/provider only render once a key is present.

## Verification (live, headless Chromium)

| Route | No key seeded | Key seeded |
|-------|---------------|------------|
| `/docs-example` | banner shown ✅, no hardcoded key ✅ | form shown ✅, no banner ✅ |
| `/docs-verification` | banner shown ✅, no hardcoded key ✅ | form shown ✅, no banner ✅ |

- ✅ Zero page errors in all four cases.
- ✅ With the key seeded, selecting the **Card Element** example on `/docs-verification` mounts a real Stripe iframe (`js.stripe.com/v3/elements-inner-card-…`) — confirming the injected key drives a live element.

> Do not merge yet — opening for morning review per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)