### PR TITLE
feat: add APAC regional elements (AU Bank Account/BECS + FPX)

### DIFF
--- a/apps/backend/src/app/api/becs-intent/route.ts
+++ b/apps/backend/src/app/api/becs-intent/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server'
+import { getStripe } from '@/lib/stripe'
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json().catch(() => ({}))
+    const stripe = getStripe()
+
+    const paymentIntent = await stripe.paymentIntents.create({
+      amount: body.amount || 1000,
+      currency: 'aud', // BECS Direct Debit only supports AUD (Australian Dollar)
+      payment_method_types: ['au_becs_debit'],
+      ...(body.description && { description: body.description }),
+      ...(body.metadata && { metadata: body.metadata }),
+      // BECS Direct Debit requires a mandate for recurring payments
+      ...(body.mandate_data && { mandate_data: body.mandate_data }),
+    })
+
+    return NextResponse.json({
+      clientSecret: paymentIntent.client_secret,
+      paymentIntentId: paymentIntent.id,
+      amount: paymentIntent.amount,
+      currency: paymentIntent.currency,
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error'
+    return NextResponse.json({ error: message }, { status: 400 })
+  }
+}
+
+// Health check
+export async function GET() {
+  return NextResponse.json({
+    endpoint: 'POST /api/becs-intent',
+    description: 'Create a BECS Direct Debit Payment Intent for Australian bank payments',
+    parameters: {
+      amount: 'number (in cents, default: 1000)',
+      description: 'string (optional)',
+      metadata: 'object (optional)',
+      mandate_data: 'object (optional, for recurring payments)',
+    },
+    notes: 'Currency is always AUD for BECS Direct Debit payments (Australia)',
+  })
+}

--- a/apps/backend/src/app/api/fpx-intent/route.ts
+++ b/apps/backend/src/app/api/fpx-intent/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server'
+import { getStripe } from '@/lib/stripe'
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json().catch(() => ({}))
+    const stripe = getStripe()
+
+    const paymentIntent = await stripe.paymentIntents.create({
+      amount: body.amount || 1000,
+      currency: 'myr', // FPX only supports MYR (Malaysian Ringgit)
+      payment_method_types: ['fpx'],
+      ...(body.description && { description: body.description }),
+      ...(body.metadata && { metadata: body.metadata }),
+    })
+
+    return NextResponse.json({
+      clientSecret: paymentIntent.client_secret,
+      paymentIntentId: paymentIntent.id,
+      amount: paymentIntent.amount,
+      currency: paymentIntent.currency,
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error'
+    return NextResponse.json({ error: message }, { status: 400 })
+  }
+}
+
+// Health check
+export async function GET() {
+  return NextResponse.json({
+    endpoint: 'POST /api/fpx-intent',
+    description: 'Create an FPX Payment Intent for Malaysian bank payments',
+    parameters: {
+      amount: 'number (in sen, default: 1000)',
+      description: 'string (optional)',
+      metadata: 'object (optional)',
+    },
+    notes: 'Currency is always MYR for FPX payments (Malaysia)',
+  })
+}

--- a/apps/backend/src/app/becs-intent/page.tsx
+++ b/apps/backend/src/app/becs-intent/page.tsx
@@ -1,0 +1,168 @@
+'use client'
+
+import * as React from 'react'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { ResultDisplay } from '@/components/result-display'
+import { Loader2 } from 'lucide-react'
+import { formatCurrency } from '@/lib/utils'
+
+interface PaymentIntentResult {
+  clientSecret: string
+  paymentIntentId: string
+  amount: number
+  currency: string
+}
+
+export default function BecsIntentPage() {
+  const [amount, setAmount] = React.useState('1000')
+  const [description, setDescription] = React.useState('')
+  const [loading, setLoading] = React.useState(false)
+  const [error, setError] = React.useState<string | null>(null)
+  const [result, setResult] = React.useState<PaymentIntentResult | null>(null)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+    setError(null)
+    setResult(null)
+
+    try {
+      const response = await fetch('/api/becs-intent', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          amount: parseInt(amount, 10),
+          ...(description && { description }),
+        }),
+      })
+
+      const data = await response.json()
+
+      if (!response.ok) {
+        throw new Error(data.error || 'Failed to create BECS Payment Intent')
+      }
+
+      setResult(data)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl">
+      <div className="mb-6">
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-green-700">
+            <span className="text-sm font-bold text-white">BECS</span>
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold">BECS Direct Debit Intent</h1>
+            <p className="text-sm text-muted-foreground">
+              Create a BECS Payment Intent for Australian bank account payments
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Configuration</CardTitle>
+          <CardDescription>
+            Configure the BECS Direct Debit payment. Currency is always AUD (Australian Dollar). The client secret can be used with
+            VueStripeAuBankAccountElement.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="amount">Amount (in cents)</Label>
+              <Input
+                id="amount"
+                type="number"
+                min="100"
+                value={amount}
+                onChange={(e) => setAmount(e.target.value)}
+                placeholder="1000"
+              />
+              <p className="text-xs text-muted-foreground">
+                {amount && formatCurrency(parseInt(amount, 10) || 0, 'aud')}
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="description">Description (optional)</Label>
+              <Input
+                id="description"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Payment for order #123"
+              />
+            </div>
+
+            {error && (
+              <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+                {error}
+              </div>
+            )}
+
+            <Button type="submit" className="w-full" disabled={loading}>
+              {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              Generate BECS Payment Intent
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      {result && (
+        <div className="mt-6">
+          <ResultDisplay
+            title="BECS Payment Intent Created"
+            fields={[
+              {
+                label: 'Client Secret',
+                value: result.clientSecret,
+              },
+              {
+                label: 'Payment Intent ID',
+                value: result.paymentIntentId,
+              },
+              {
+                label: 'Amount',
+                value: formatCurrency(result.amount, result.currency),
+                copyable: false,
+              },
+            ]}
+          />
+
+          <Card className="mt-4 border-dashed">
+            <CardContent className="py-4">
+              <p className="mb-2 text-sm font-medium">Usage Example:</p>
+              <pre className="overflow-x-auto rounded-md bg-muted p-3 text-xs">
+                {`<VueStripeElements
+  :stripe-key="publishableKey"
+  :client-secret="'${result.clientSecret}'"
+>
+  <VueStripeAuBankAccountElement />
+</VueStripeElements>`}
+              </pre>
+            </CardContent>
+          </Card>
+
+          <Card className="mt-4 border-amber-200 bg-amber-50">
+            <CardContent className="py-4">
+              <p className="text-sm text-amber-800">
+                <strong>Note:</strong> BECS Direct Debit payments require customer agreement to the
+                Direct Debit Request Service Agreement. Payments typically settle in 3-4 business days.
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/backend/src/app/fpx-intent/page.tsx
+++ b/apps/backend/src/app/fpx-intent/page.tsx
@@ -1,0 +1,161 @@
+'use client'
+
+import * as React from 'react'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { ResultDisplay } from '@/components/result-display'
+import { Loader2 } from 'lucide-react'
+import { formatCurrency } from '@/lib/utils'
+
+interface PaymentIntentResult {
+  clientSecret: string
+  paymentIntentId: string
+  amount: number
+  currency: string
+}
+
+export default function FpxIntentPage() {
+  const [amount, setAmount] = React.useState('1000')
+  const [description, setDescription] = React.useState('')
+  const [loading, setLoading] = React.useState(false)
+  const [error, setError] = React.useState<string | null>(null)
+  const [result, setResult] = React.useState<PaymentIntentResult | null>(null)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+    setError(null)
+    setResult(null)
+
+    try {
+      const response = await fetch('/api/fpx-intent', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          amount: parseInt(amount, 10),
+          ...(description && { description }),
+        }),
+      })
+
+      const data = await response.json()
+
+      if (!response.ok) {
+        throw new Error(data.error || 'Failed to create FPX Payment Intent')
+      }
+
+      setResult(data)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl">
+      <div className="mb-6">
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-600">
+            <span className="text-lg font-bold text-white">FPX</span>
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold">FPX Payment Intent</h1>
+            <p className="text-sm text-muted-foreground">
+              Create an FPX Payment Intent for Malaysian bank payments
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Configuration</CardTitle>
+          <CardDescription>
+            Configure the FPX payment. Currency is always MYR (Malaysian Ringgit). The client secret can be used with
+            VueStripeFpxBankElement.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="amount">Amount (in cents)</Label>
+              <Input
+                id="amount"
+                type="number"
+                min="200"
+                value={amount}
+                onChange={(e) => setAmount(e.target.value)}
+                placeholder="1000"
+              />
+              <p className="text-xs text-muted-foreground">
+                {amount && formatCurrency(parseInt(amount, 10) || 0, 'myr')}
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="description">Description (optional)</Label>
+              <Input
+                id="description"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Payment for order #123"
+              />
+            </div>
+
+            {error && (
+              <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+                {error}
+              </div>
+            )}
+
+            <Button type="submit" className="w-full" disabled={loading}>
+              {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              Generate FPX Payment Intent
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      {result && (
+        <div className="mt-6">
+          <ResultDisplay
+            title="FPX Payment Intent Created"
+            fields={[
+              {
+                label: 'Client Secret',
+                value: result.clientSecret,
+              },
+              {
+                label: 'Payment Intent ID',
+                value: result.paymentIntentId,
+              },
+              {
+                label: 'Amount',
+                value: formatCurrency(result.amount, result.currency),
+                copyable: false,
+              },
+            ]}
+          />
+
+          <Card className="mt-4 border-dashed">
+            <CardContent className="py-4">
+              <p className="mb-2 text-sm font-medium">Usage Example:</p>
+              <pre className="overflow-x-auto rounded-md bg-muted p-3 text-xs">
+                {`<VueStripeElements
+  :stripe-key="publishableKey"
+  :client-secret="'${result.clientSecret}'"
+>
+  <VueStripeFpxBankElement
+    account-holder-type="individual"
+  />
+</VueStripeElements>`}
+              </pre>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/backend/src/components/sidebar.tsx
+++ b/apps/backend/src/components/sidebar.tsx
@@ -72,6 +72,21 @@ const euPayments = [
   },
 ]
 
+const apacPayments = [
+  {
+    name: 'FPX (Malaysia)',
+    href: '/fpx-intent',
+    icon: Landmark,
+    description: 'Malaysian bank payments',
+  },
+  {
+    name: 'BECS (Australia)',
+    href: '/becs-intent',
+    icon: Landmark,
+    description: 'AU Direct Debit',
+  },
+]
+
 const externalLinks = [
   {
     name: 'Vue Stripe Docs',
@@ -161,6 +176,33 @@ export function Sidebar() {
           EU Payments
         </p>
         {euPayments.map((item) => {
+          const isActive = pathname === item.href
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={cn(
+                'flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors',
+                isActive
+                  ? 'bg-primary text-primary-foreground'
+                  : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+              )}
+            >
+              <item.icon className="h-4 w-4" />
+              <div>
+                <p className="font-medium">{item.name}</p>
+                {!isActive && (
+                  <p className="text-xs opacity-70">{item.description}</p>
+                )}
+              </div>
+            </Link>
+          )
+        })}
+
+        <p className="mb-2 mt-4 px-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+          APAC Payments
+        </p>
+        {apacPayments.map((item) => {
           const isActive = pathname === item.href
           return (
             <Link

--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -158,6 +158,13 @@ if (window.location.hostname === 'localhost' || window.location.hostname === '12
           ]
         },
         {
+          text: 'APAC Elements',
+          items: [
+            { text: 'FPX Bank Element', link: '/guide/fpx-bank-element' },
+            { text: 'AU Bank Account Element', link: '/guide/au-bank-account-element' },
+          ]
+        },
+        {
           text: 'Subscriptions',
           items: [
             { text: 'Pricing Table', link: '/guide/pricing-table' },
@@ -204,6 +211,13 @@ if (window.location.hostname === 'localhost' || window.location.hostname === '12
             { text: 'VueStripeIdealBankElement', link: '/api/components/stripe-ideal-bank-element' },
             { text: 'VueStripeP24BankElement', link: '/api/components/stripe-p24-bank-element' },
             { text: 'VueStripeEpsBankElement', link: '/api/components/stripe-eps-bank-element' },
+          ]
+        },
+        {
+          text: 'APAC Elements',
+          items: [
+            { text: 'VueStripeFpxBankElement', link: '/api/components/stripe-fpx-bank-element' },
+            { text: 'VueStripeAuBankAccountElement', link: '/api/components/stripe-au-bank-account-element' },
           ]
         },
         {
@@ -271,6 +285,13 @@ if (window.location.hostname === 'localhost' || window.location.hostname === '12
             { text: 'SEPA Direct Debit', link: '/live-demo/iban-element' },
             { text: 'Przelewy24 (Poland)', link: '/live-demo/p24-payment' },
             { text: 'EPS (Austria)', link: '/live-demo/eps-payment' },
+          ]
+        },
+        {
+          text: 'APAC Payments',
+          items: [
+            { text: 'FPX (Malaysia)', link: '/live-demo/fpx-payment' },
+            { text: 'BECS Direct Debit (Australia)', link: '/live-demo/becs-payment' },
           ]
         },
         {

--- a/apps/docs/.vitepress/theme/components/examples/AuBankAccountPaymentExample.vue
+++ b/apps/docs/.vitepress/theme/components/examples/AuBankAccountPaymentExample.vue
@@ -1,0 +1,359 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import {
+  VueStripeProvider,
+  VueStripeElements,
+  VueStripeAuBankAccountElement,
+  useStripe,
+  useStripeElements,
+} from '@vue-stripe/vue-stripe'
+import ProductSelector from './ProductSelector.vue'
+import PaymentStatus from './PaymentStatus.vue'
+import { useBackendApi, type Product } from '../../composables/useBackendApi'
+import { useStripeConfig } from '../../composables/useStripeConfig'
+
+const { publishableKey } = useStripeConfig()
+const { createBecsIntent, loading, error } = useBackendApi()
+
+// Step management: Product → Payment → Complete
+const step = ref<'select' | 'payment' | 'complete'>('select')
+
+// State
+const selectedProduct = ref<Product | null>(null)
+const clientSecret = ref<string | null>(null)
+const paymentIntentId = ref<string | null>(null)
+const bankName = ref<string | null>(null)
+const branchName = ref<string | null>(null)
+const isComplete = ref(false)
+const mandateAccepted = ref(false)
+const customerName = ref('')
+const customerEmail = ref('')
+const confirming = ref(false)
+const confirmError = ref<string | null>(null)
+
+const canConfirm = computed(() =>
+  clientSecret.value &&
+  isComplete.value &&
+  mandateAccepted.value &&
+  customerName.value.trim() &&
+  customerEmail.value.trim() &&
+  !confirming.value
+)
+
+// Auto-create intent on product select
+async function onProductSelected(product: Product) {
+  selectedProduct.value = product
+  confirmError.value = null
+
+  try {
+    const result = await createBecsIntent({
+      amount: product.price.amount || 1000,
+      description: `Payment for ${product.name}`,
+    })
+    clientSecret.value = result.clientSecret
+    paymentIntentId.value = result.paymentIntentId
+    step.value = 'payment'
+  } catch (err) {
+    confirmError.value = err instanceof Error ? err.message : 'Failed to create payment intent'
+  }
+}
+
+function onAuBankChange(event: any) {
+  isComplete.value = event.complete
+  if (event.bankName) bankName.value = event.bankName
+  if (event.branchName) branchName.value = event.branchName
+}
+
+function reset() {
+  step.value = 'select'
+  selectedProduct.value = null
+  clientSecret.value = null
+  paymentIntentId.value = null
+  bankName.value = null
+  branchName.value = null
+  isComplete.value = false
+  mandateAccepted.value = false
+  customerName.value = ''
+  customerEmail.value = ''
+  confirmError.value = null
+}
+</script>
+
+<template>
+  <div class="au-bank-payment-example">
+    <div v-if="!publishableKey" class="warning-box">
+      <strong>Missing Configuration</strong>
+      <p>Please set <code>VITE_STRIPE_PUBLISHABLE_KEY</code> in your <code>.env</code> file.</p>
+    </div>
+
+    <template v-else>
+      <PaymentStatus />
+
+      <!-- Progress Steps -->
+      <div class="progress-steps">
+        <div class="progress-step" :class="{ active: step === 'select', completed: step !== 'select' }">
+          <span class="step-dot">1</span>
+          <span class="step-label">Product</span>
+        </div>
+        <div class="progress-line" :class="{ completed: step !== 'select' }"></div>
+        <div class="progress-step" :class="{ active: step === 'payment', completed: step === 'complete' }">
+          <span class="step-dot">2</span>
+          <span class="step-label">Payment</span>
+        </div>
+        <div class="progress-line" :class="{ completed: step === 'complete' }"></div>
+        <div class="progress-step" :class="{ active: step === 'complete' }">
+          <span class="step-dot">✓</span>
+          <span class="step-label">Complete</span>
+        </div>
+      </div>
+
+      <!-- Step 1: Select Product -->
+      <div v-if="step === 'select'" class="step-content">
+        <ProductSelector filter="one_time" @select="onProductSelected" />
+        <div v-if="loading" class="loading-state">
+          <span class="spinner"></span> Creating payment intent...
+        </div>
+        <div v-if="confirmError || error" class="error-box">
+          <strong>Error:</strong> {{ confirmError || error }}
+        </div>
+      </div>
+
+      <!-- Step 2: Payment (BECS Direct Debit) -->
+      <div v-else-if="step === 'payment'" class="step-content">
+        <div class="step-section">
+          <div class="step-header">
+            <h4>BECS Direct Debit (Australia)</h4>
+            <button class="change-btn" @click="reset">Change Product</button>
+          </div>
+
+          <div class="product-summary">
+            <span>{{ selectedProduct?.name }}</span>
+            <span class="price">AUD {{ ((selectedProduct?.price.amount || 0) / 100).toFixed(2) }}</span>
+          </div>
+
+          <!-- Customer Details -->
+          <div class="customer-fields">
+            <div class="field">
+              <label for="name">Full Name <span class="required">*</span></label>
+              <input
+                id="name"
+                v-model="customerName"
+                type="text"
+                placeholder="John Smith"
+                required
+              />
+            </div>
+            <div class="field">
+              <label for="email">Email <span class="required">*</span></label>
+              <input
+                id="email"
+                v-model="customerEmail"
+                type="email"
+                placeholder="john@example.com"
+                required
+              />
+            </div>
+          </div>
+
+          <div class="stripe-container">
+            <VueStripeProvider :publishable-key="publishableKey">
+              <VueStripeElements :client-secret="clientSecret!">
+                <div class="field">
+                  <label>Bank Account (BSB & Account Number)</label>
+                  <div class="au-bank-element-wrapper">
+                    <VueStripeAuBankAccountElement
+                      :options="{ iconStyle: 'solid' }"
+                      @change="onAuBankChange"
+                    />
+                  </div>
+                </div>
+
+                <div v-if="bankName" class="bank-info">
+                  <span class="icon">🏦</span>
+                  <div class="bank-details">
+                    <strong>{{ bankName }}</strong>
+                    <span v-if="branchName"> - {{ branchName }}</span>
+                  </div>
+                </div>
+
+                <!-- Mandate Agreement -->
+                <div class="mandate-section">
+                  <label class="mandate-checkbox">
+                    <input
+                      v-model="mandateAccepted"
+                      type="checkbox"
+                    />
+                    <span class="mandate-text">
+                      By providing your bank account details and confirming this payment, you agree to this Direct Debit Request and the
+                      <a href="https://stripe.com/au-becs-dd-service-agreement/legal" target="_blank" rel="noopener">
+                        Direct Debit Request service agreement
+                      </a>.
+                    </span>
+                  </label>
+                </div>
+
+                <ConfirmBecsButton
+                  :can-confirm="canConfirm"
+                  :confirming="confirming"
+                  :client-secret="clientSecret!"
+                  :amount="selectedProduct?.price?.amount"
+                  :customer-name="customerName"
+                  :customer-email="customerEmail"
+                  @confirm-start="confirming = true"
+                  @confirm-end="confirming = false"
+                  @success="step = 'complete'"
+                  @error="(e) => confirmError = e"
+                />
+              </VueStripeElements>
+            </VueStripeProvider>
+          </div>
+
+          <div v-if="confirmError" class="error-box">
+            <strong>Payment Error:</strong> {{ confirmError }}
+          </div>
+        </div>
+      </div>
+
+      <!-- Step 3: Complete -->
+      <div v-else-if="step === 'complete'" class="step-content">
+        <div class="success-state">
+          <span class="success-icon">✓</span>
+          <h4>Payment Initiated!</h4>
+          <p>Thank you for your purchase of {{ selectedProduct?.name }}.</p>
+          <p class="note">BECS Direct Debit payments typically settle in 3-4 business days.</p>
+          <p v-if="paymentIntentId" class="payment-id">Payment ID: <code>{{ paymentIntentId }}</code></p>
+          <button class="reset-btn" @click="reset">Start Over</button>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, h } from 'vue'
+
+const ConfirmBecsButton = defineComponent({
+  name: 'ConfirmBecsButton',
+  props: { canConfirm: Boolean, confirming: Boolean, clientSecret: String, amount: Number, customerName: String, customerEmail: String },
+  emits: ['confirm-start', 'confirm-end', 'success', 'error'],
+  setup(props, { emit }) {
+    const { stripe } = useStripe()
+    const { elements } = useStripeElements()
+
+    function formatPrice(amount: number | undefined) {
+      if (!amount) return ''
+      return `AUD ${(amount / 100).toFixed(2)}`
+    }
+
+    async function confirmPayment() {
+      emit('confirm-start')
+      emit('error', null)
+      try {
+        if (!stripe.value || !elements.value) throw new Error('Stripe not initialized')
+
+        const auBankElement = elements.value.getElement('auBankAccount')
+        if (!auBankElement) throw new Error('AU Bank Account element not found')
+
+        const { error, paymentIntent } = await stripe.value.confirmAuBecsDebitPayment(
+          props.clientSecret || '',
+          {
+            payment_method: {
+              au_becs_debit: auBankElement,
+              billing_details: {
+                name: props.customerName || '',
+                email: props.customerEmail || '',
+              },
+            },
+          }
+        )
+        if (error) throw new Error(error.message)
+        if (paymentIntent?.status === 'processing') emit('success')
+      } catch (err) {
+        emit('error', err instanceof Error ? err.message : 'Payment failed')
+      } finally {
+        emit('confirm-end')
+      }
+    }
+
+    return () => h('button', {
+      class: ['confirm-btn', { disabled: !props.canConfirm || props.confirming }],
+      disabled: !props.canConfirm || props.confirming,
+      onClick: confirmPayment,
+    }, props.confirming ? 'Processing...' : `Pay ${formatPrice(props.amount)} with BECS`)
+  },
+})
+
+export default { components: { ConfirmBecsButton } }
+</script>
+
+<style scoped>
+.au-bank-payment-example { padding: 1.5rem; background: var(--vp-c-bg); border: 1px solid var(--vp-c-divider); border-radius: 12px; }
+.warning-box { padding: 1rem; background: var(--vp-c-yellow-soft); border: 1px solid var(--vp-c-yellow-1); border-radius: 8px; color: var(--vp-c-yellow-darker); }
+.warning-box strong { display: block; margin-bottom: 0.5rem; }
+.warning-box p { margin: 0; font-size: 0.875rem; }
+.warning-box code { padding: 0.125rem 0.375rem; background: rgba(0,0,0,0.1); border-radius: 3px; }
+
+.progress-steps { display: flex; align-items: center; justify-content: center; margin-bottom: 2rem; padding: 1rem 0; }
+.progress-step { display: flex; flex-direction: column; align-items: center; gap: 0.5rem; }
+.step-dot { display: inline-flex; align-items: center; justify-content: center; width: 2rem; height: 2rem; background: var(--vp-c-bg-soft); border: 2px solid var(--vp-c-divider); border-radius: 50%; font-size: 0.875rem; font-weight: 600; color: var(--vp-c-text-2); transition: all 0.2s; }
+.progress-step.active .step-dot { background: var(--vp-c-brand-1); border-color: var(--vp-c-brand-1); color: white; }
+.progress-step.completed .step-dot { background: var(--vp-c-green-1); border-color: var(--vp-c-green-1); color: white; }
+.step-label { font-size: 0.75rem; color: var(--vp-c-text-2); }
+.progress-step.active .step-label { color: var(--vp-c-brand-1); font-weight: 500; }
+.progress-step.completed .step-label { color: var(--vp-c-green-1); }
+.progress-line { width: 4rem; height: 2px; background: var(--vp-c-divider); margin: 0 0.5rem; margin-bottom: 1.5rem; transition: background 0.2s; }
+.progress-line.completed { background: var(--vp-c-green-1); }
+
+.step-content { min-height: 200px; }
+.loading-state { display: flex; align-items: center; justify-content: center; gap: 0.5rem; margin-top: 1rem; padding: 1rem; background: var(--vp-c-bg-soft); border-radius: 8px; color: var(--vp-c-text-2); }
+
+.step-section { padding: 1.5rem; background: var(--vp-c-bg-soft); border-radius: 8px; }
+.step-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 1rem; }
+.step-header h4 { margin: 0; font-size: 1rem; font-weight: 600; }
+.change-btn { padding: 0.25rem 0.75rem; background: transparent; border: 1px solid var(--vp-c-divider); border-radius: 4px; font-size: 0.75rem; color: var(--vp-c-text-2); cursor: pointer; }
+.change-btn:hover { border-color: var(--vp-c-brand-1); color: var(--vp-c-brand-1); }
+
+.product-summary { display: flex; justify-content: space-between; align-items: center; padding: 0.75rem 1rem; margin-bottom: 1rem; background: var(--vp-c-bg); border-radius: 6px; }
+.product-summary .price { font-weight: 700; color: var(--vp-c-brand-1); }
+
+.customer-fields { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-bottom: 1rem; }
+@media (max-width: 640px) { .customer-fields { grid-template-columns: 1fr; } }
+
+.field { display: flex; flex-direction: column; gap: 0.5rem; }
+.field label { font-size: 0.875rem; font-weight: 500; color: var(--vp-c-text-1); }
+.field .required { color: var(--vp-c-danger-1); }
+.field input { padding: 0.75rem 1rem; border: 1px solid var(--vp-c-divider); border-radius: 6px; font-size: 1rem; background: var(--vp-c-bg); color: var(--vp-c-text-1); }
+.field input:focus { outline: none; border-color: var(--vp-c-brand-1); }
+
+.stripe-container { padding: 1rem; background: var(--vp-c-bg); border-radius: 8px; }
+
+.au-bank-element-wrapper { padding: 0.75rem; background: white; border: 1px solid var(--vp-c-divider); border-radius: 6px; }
+:root.dark .au-bank-element-wrapper { background: #1a1a1a; }
+
+.bank-info { display: flex; align-items: center; gap: 0.5rem; margin-top: 1rem; padding: 0.75rem 1rem; background: var(--vp-c-green-soft); border-radius: 6px; font-size: 0.875rem; color: var(--vp-c-green-1); }
+.bank-details { display: flex; flex-wrap: wrap; gap: 0.25rem; }
+
+.mandate-section { margin-top: 1rem; padding: 1rem; background: var(--vp-c-bg-soft); border-radius: 6px; }
+.mandate-checkbox { display: flex; gap: 0.75rem; cursor: pointer; font-size: 0.8125rem; line-height: 1.5; color: var(--vp-c-text-2); }
+.mandate-checkbox input { flex-shrink: 0; width: 1.125rem; height: 1.125rem; margin-top: 0.125rem; }
+.mandate-text a { color: var(--vp-c-brand-1); text-decoration: underline; }
+
+.confirm-btn { display: flex; align-items: center; justify-content: center; gap: 0.5rem; width: 100%; margin-top: 1rem; padding: 0.875rem 1.5rem; background: #002d5b; color: white; border: none; border-radius: 6px; font-size: 1rem; font-weight: 600; cursor: pointer; transition: opacity 0.2s; }
+.confirm-btn:hover:not(.disabled) { opacity: 0.9; }
+.confirm-btn.disabled { opacity: 0.6; cursor: not-allowed; }
+
+.error-box { margin-top: 1rem; padding: 0.75rem 1rem; background: var(--vp-c-danger-soft); border: 1px solid var(--vp-c-danger-1); border-radius: 6px; color: var(--vp-c-danger-1); font-size: 0.875rem; }
+
+.success-state { text-align: center; padding: 2rem; }
+.success-icon { display: inline-flex; align-items: center; justify-content: center; width: 4rem; height: 4rem; background: var(--vp-c-green-1); color: white; border-radius: 50%; font-size: 2rem; margin-bottom: 1rem; }
+.success-state h4 { margin: 0 0 0.5rem 0; font-size: 1.25rem; }
+.success-state p { margin: 0.5rem 0; color: var(--vp-c-text-2); }
+.success-state .note { font-style: italic; }
+.payment-id { margin-top: 1rem; }
+.payment-id code { padding: 0.25rem 0.5rem; background: var(--vp-c-bg-soft); border-radius: 4px; font-size: 0.75rem; }
+.reset-btn { margin-top: 1.5rem; padding: 0.75rem 1.5rem; background: var(--vp-c-bg-soft); border: 1px solid var(--vp-c-divider); border-radius: 6px; font-size: 0.875rem; cursor: pointer; }
+.reset-btn:hover { border-color: var(--vp-c-brand-1); color: var(--vp-c-brand-1); }
+
+.spinner { width: 1rem; height: 1rem; border: 2px solid var(--vp-c-divider); border-top-color: var(--vp-c-brand-1); border-radius: 50%; animation: spin 0.8s linear infinite; }
+@keyframes spin { to { transform: rotate(360deg); } }
+</style>

--- a/apps/docs/.vitepress/theme/components/examples/FpxPaymentExample.vue
+++ b/apps/docs/.vitepress/theme/components/examples/FpxPaymentExample.vue
@@ -1,0 +1,297 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import {
+  VueStripeProvider,
+  VueStripeElements,
+  VueStripeFpxBankElement,
+  useStripe,
+  useStripeElements,
+} from '@vue-stripe/vue-stripe'
+import ProductSelector from './ProductSelector.vue'
+import PaymentStatus from './PaymentStatus.vue'
+import { useBackendApi, type Product } from '../../composables/useBackendApi'
+import { useStripeConfig } from '../../composables/useStripeConfig'
+
+const { publishableKey } = useStripeConfig()
+const { createFpxIntent, loading, error } = useBackendApi()
+
+// Step management: Product → Payment → Complete
+const step = ref<'select' | 'payment' | 'complete'>('select')
+
+// State
+const selectedProduct = ref<Product | null>(null)
+const clientSecret = ref<string | null>(null)
+const paymentIntentId = ref<string | null>(null)
+const selectedBank = ref<string | null>(null)
+const accountHolderType = ref<'individual' | 'company'>('individual')
+const confirming = ref(false)
+const confirmError = ref<string | null>(null)
+
+const canConfirm = computed(() => clientSecret.value && selectedBank.value && !confirming.value)
+
+// Auto-create intent on product select
+async function onProductSelected(product: Product) {
+  selectedProduct.value = product
+  confirmError.value = null
+
+  try {
+    const result = await createFpxIntent({
+      amount: product.price.amount || 1000,
+      description: `Payment for ${product.name}`,
+    })
+    clientSecret.value = result.clientSecret
+    paymentIntentId.value = result.paymentIntentId
+    step.value = 'payment'
+  } catch (err) {
+    confirmError.value = err instanceof Error ? err.message : 'Failed to create payment intent'
+  }
+}
+
+function onFpxChange(event: any) {
+  selectedBank.value = event.value || null
+}
+
+function reset() {
+  step.value = 'select'
+  selectedProduct.value = null
+  clientSecret.value = null
+  paymentIntentId.value = null
+  selectedBank.value = null
+  confirmError.value = null
+}
+</script>
+
+<template>
+  <div class="fpx-payment-example">
+    <div v-if="!publishableKey" class="warning-box">
+      <strong>Missing Configuration</strong>
+      <p>Please set <code>VITE_STRIPE_PUBLISHABLE_KEY</code> in your <code>.env</code> file.</p>
+    </div>
+
+    <template v-else>
+      <PaymentStatus />
+
+      <!-- Progress Steps -->
+      <div class="progress-steps">
+        <div class="progress-step" :class="{ active: step === 'select', completed: step !== 'select' }">
+          <span class="step-dot">1</span>
+          <span class="step-label">Product</span>
+        </div>
+        <div class="progress-line" :class="{ completed: step !== 'select' }"></div>
+        <div class="progress-step" :class="{ active: step === 'payment', completed: step === 'complete' }">
+          <span class="step-dot">2</span>
+          <span class="step-label">Payment</span>
+        </div>
+        <div class="progress-line" :class="{ completed: step === 'complete' }"></div>
+        <div class="progress-step" :class="{ active: step === 'complete' }">
+          <span class="step-dot">✓</span>
+          <span class="step-label">Complete</span>
+        </div>
+      </div>
+
+      <!-- Step 1: Select Product -->
+      <div v-if="step === 'select'" class="step-content">
+        <ProductSelector filter="one_time" @select="onProductSelected" />
+        <div v-if="loading" class="loading-state">
+          <span class="spinner"></span> Creating payment intent...
+        </div>
+        <div v-if="confirmError || error" class="error-box">
+          <strong>Error:</strong> {{ confirmError || error }}
+        </div>
+      </div>
+
+      <!-- Step 2: Payment (Bank Selection) -->
+      <div v-else-if="step === 'payment'" class="step-content">
+        <div class="step-section">
+          <div class="step-header">
+            <h4>Select Your Bank (FPX - Malaysia)</h4>
+            <button class="change-btn" @click="reset">Change Product</button>
+          </div>
+
+          <div class="product-summary">
+            <span>{{ selectedProduct?.name }}</span>
+            <span class="price">MYR {{ ((selectedProduct?.price.amount || 0) / 100).toFixed(2) }}</span>
+          </div>
+
+          <!-- Account Type Selection -->
+          <div class="account-type-selector">
+            <label class="account-type-option">
+              <input
+                v-model="accountHolderType"
+                type="radio"
+                value="individual"
+              />
+              <span>Individual Account</span>
+            </label>
+            <label class="account-type-option">
+              <input
+                v-model="accountHolderType"
+                type="radio"
+                value="company"
+              />
+              <span>Business Account</span>
+            </label>
+          </div>
+
+          <div class="stripe-container">
+            <VueStripeProvider :publishable-key="publishableKey">
+              <VueStripeElements :client-secret="clientSecret!">
+                <div class="fpx-element-wrapper">
+                  <VueStripeFpxBankElement
+                    :account-holder-type="accountHolderType"
+                    @change="onFpxChange"
+                  />
+                </div>
+
+                <div v-if="selectedBank" class="bank-selected">
+                  <span class="icon">🏦</span>
+                  Selected bank: <strong>{{ selectedBank }}</strong>
+                </div>
+
+                <ConfirmFpxButton
+                  :can-confirm="canConfirm"
+                  :confirming="confirming"
+                  :client-secret="clientSecret!"
+                  :amount="selectedProduct?.price?.amount"
+                  @confirm-start="confirming = true"
+                  @confirm-end="confirming = false"
+                  @success="step = 'complete'"
+                  @error="(e) => confirmError = e"
+                />
+              </VueStripeElements>
+            </VueStripeProvider>
+          </div>
+
+          <div v-if="confirmError" class="error-box">
+            <strong>Payment Error:</strong> {{ confirmError }}
+          </div>
+        </div>
+      </div>
+
+      <!-- Step 3: Complete -->
+      <div v-else-if="step === 'complete'" class="step-content">
+        <div class="success-state">
+          <span class="success-icon">✓</span>
+          <h4>Payment Initiated!</h4>
+          <p>Thank you for your purchase of {{ selectedProduct?.name }}.</p>
+          <p class="note">You will be redirected to your bank to complete the payment.</p>
+          <p v-if="paymentIntentId" class="payment-id">Payment ID: <code>{{ paymentIntentId }}</code></p>
+          <button class="reset-btn" @click="reset">Start Over</button>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, h } from 'vue'
+
+const ConfirmFpxButton = defineComponent({
+  name: 'ConfirmFpxButton',
+  props: { canConfirm: Boolean, confirming: Boolean, clientSecret: String, amount: Number },
+  emits: ['confirm-start', 'confirm-end', 'success', 'error'],
+  setup(props, { emit }) {
+    const { stripe } = useStripe()
+    const { elements } = useStripeElements()
+
+    function formatPrice(amount: number | undefined) {
+      if (!amount) return ''
+      return `MYR ${(amount / 100).toFixed(2)}`
+    }
+
+    async function confirmPayment() {
+      emit('confirm-start')
+      emit('error', null)
+      try {
+        if (!stripe.value || !elements.value) throw new Error('Stripe not initialized')
+
+        const fpxBankElement = elements.value.getElement('fpxBank')
+        if (!fpxBankElement) throw new Error('FPX element not found')
+
+        const { error, paymentIntent } = await stripe.value.confirmFpxPayment(
+          props.clientSecret || '',
+          {
+            payment_method: { fpx: fpxBankElement },
+            return_url: window.location.href,
+          }
+        )
+        if (error) throw new Error(error.message)
+        if (paymentIntent) emit('success')
+      } catch (err) {
+        emit('error', err instanceof Error ? err.message : 'Payment failed')
+      } finally {
+        emit('confirm-end')
+      }
+    }
+
+    return () => h('button', {
+      class: ['confirm-btn', { disabled: !props.canConfirm || props.confirming }],
+      disabled: !props.canConfirm || props.confirming,
+      onClick: confirmPayment,
+    }, props.confirming ? 'Redirecting to bank...' : `Pay ${formatPrice(props.amount)} with FPX`)
+  },
+})
+
+export default { components: { ConfirmFpxButton } }
+</script>
+
+<style scoped>
+.fpx-payment-example { padding: 1.5rem; background: var(--vp-c-bg); border: 1px solid var(--vp-c-divider); border-radius: 12px; }
+.warning-box { padding: 1rem; background: var(--vp-c-yellow-soft); border: 1px solid var(--vp-c-yellow-1); border-radius: 8px; color: var(--vp-c-yellow-darker); }
+.warning-box strong { display: block; margin-bottom: 0.5rem; }
+.warning-box p { margin: 0; font-size: 0.875rem; }
+.warning-box code { padding: 0.125rem 0.375rem; background: rgba(0,0,0,0.1); border-radius: 3px; }
+
+.progress-steps { display: flex; align-items: center; justify-content: center; margin-bottom: 2rem; padding: 1rem 0; }
+.progress-step { display: flex; flex-direction: column; align-items: center; gap: 0.5rem; }
+.step-dot { display: inline-flex; align-items: center; justify-content: center; width: 2rem; height: 2rem; background: var(--vp-c-bg-soft); border: 2px solid var(--vp-c-divider); border-radius: 50%; font-size: 0.875rem; font-weight: 600; color: var(--vp-c-text-2); transition: all 0.2s; }
+.progress-step.active .step-dot { background: var(--vp-c-brand-1); border-color: var(--vp-c-brand-1); color: white; }
+.progress-step.completed .step-dot { background: var(--vp-c-green-1); border-color: var(--vp-c-green-1); color: white; }
+.step-label { font-size: 0.75rem; color: var(--vp-c-text-2); }
+.progress-step.active .step-label { color: var(--vp-c-brand-1); font-weight: 500; }
+.progress-step.completed .step-label { color: var(--vp-c-green-1); }
+.progress-line { width: 4rem; height: 2px; background: var(--vp-c-divider); margin: 0 0.5rem; margin-bottom: 1.5rem; transition: background 0.2s; }
+.progress-line.completed { background: var(--vp-c-green-1); }
+
+.step-content { min-height: 200px; }
+.loading-state { display: flex; align-items: center; justify-content: center; gap: 0.5rem; margin-top: 1rem; padding: 1rem; background: var(--vp-c-bg-soft); border-radius: 8px; color: var(--vp-c-text-2); }
+
+.step-section { padding: 1.5rem; background: var(--vp-c-bg-soft); border-radius: 8px; }
+.step-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 1rem; }
+.step-header h4 { margin: 0; font-size: 1rem; font-weight: 600; }
+.change-btn { padding: 0.25rem 0.75rem; background: transparent; border: 1px solid var(--vp-c-divider); border-radius: 4px; font-size: 0.75rem; color: var(--vp-c-text-2); cursor: pointer; }
+.change-btn:hover { border-color: var(--vp-c-brand-1); color: var(--vp-c-brand-1); }
+
+.product-summary { display: flex; justify-content: space-between; align-items: center; padding: 0.75rem 1rem; margin-bottom: 1rem; background: var(--vp-c-bg); border-radius: 6px; }
+.product-summary .price { font-weight: 700; color: var(--vp-c-brand-1); }
+
+.account-type-selector { display: flex; gap: 1rem; margin-bottom: 1rem; }
+.account-type-option { display: flex; align-items: center; gap: 0.5rem; padding: 0.5rem 1rem; background: var(--vp-c-bg); border: 1px solid var(--vp-c-divider); border-radius: 6px; cursor: pointer; font-size: 0.875rem; }
+.account-type-option:has(input:checked) { border-color: var(--vp-c-brand-1); background: var(--vp-c-brand-soft); }
+
+.stripe-container { padding: 1rem; background: var(--vp-c-bg); border-radius: 8px; }
+
+.fpx-element-wrapper { padding: 0.75rem; background: white; border: 1px solid var(--vp-c-divider); border-radius: 6px; }
+:root.dark .fpx-element-wrapper { background: #1a1a1a; }
+
+.bank-selected { display: flex; align-items: center; gap: 0.5rem; margin-top: 1rem; padding: 0.75rem 1rem; background: var(--vp-c-green-soft); border-radius: 6px; font-size: 0.875rem; color: var(--vp-c-green-1); }
+
+.confirm-btn { display: flex; align-items: center; justify-content: center; gap: 0.5rem; width: 100%; margin-top: 1rem; padding: 0.875rem 1.5rem; background: #1d4ed8; color: white; border: none; border-radius: 6px; font-size: 1rem; font-weight: 600; cursor: pointer; transition: opacity 0.2s; }
+.confirm-btn:hover:not(.disabled) { opacity: 0.9; }
+.confirm-btn.disabled { opacity: 0.6; cursor: not-allowed; }
+
+.error-box { margin-top: 1rem; padding: 0.75rem 1rem; background: var(--vp-c-danger-soft); border: 1px solid var(--vp-c-danger-1); border-radius: 6px; color: var(--vp-c-danger-1); font-size: 0.875rem; }
+
+.success-state { text-align: center; padding: 2rem; }
+.success-icon { display: inline-flex; align-items: center; justify-content: center; width: 4rem; height: 4rem; background: var(--vp-c-green-1); color: white; border-radius: 50%; font-size: 2rem; margin-bottom: 1rem; }
+.success-state h4 { margin: 0 0 0.5rem 0; font-size: 1.25rem; }
+.success-state p { margin: 0.5rem 0; color: var(--vp-c-text-2); }
+.success-state .note { font-style: italic; }
+.payment-id { margin-top: 1rem; }
+.payment-id code { padding: 0.25rem 0.5rem; background: var(--vp-c-bg-soft); border-radius: 4px; font-size: 0.75rem; }
+.reset-btn { margin-top: 1.5rem; padding: 0.75rem 1.5rem; background: var(--vp-c-bg-soft); border: 1px solid var(--vp-c-divider); border-radius: 6px; font-size: 0.875rem; cursor: pointer; }
+.reset-btn:hover { border-color: var(--vp-c-brand-1); color: var(--vp-c-brand-1); }
+
+.spinner { width: 1rem; height: 1rem; border: 2px solid var(--vp-c-divider); border-top-color: var(--vp-c-brand-1); border-radius: 50%; animation: spin 0.8s linear infinite; }
+@keyframes spin { to { transform: rotate(360deg); } }
+</style>

--- a/apps/docs/.vitepress/theme/composables/useBackendApi.ts
+++ b/apps/docs/.vitepress/theme/composables/useBackendApi.ts
@@ -180,6 +180,70 @@ export function useBackendApi() {
     createRegionalIntent('p24-intent', options)
 
   /**
+   * Create an FPX payment intent (MYR only - Malaysia)
+   */
+  async function createFpxIntent(options: {
+    amount?: number
+    description?: string
+    metadata?: Record<string, string>
+  } = {}): Promise<PaymentIntentResult> {
+    loading.value = true
+    error.value = null
+
+    try {
+      const response = await fetch(`${apiUrl.value}/api/fpx-intent`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(options),
+      })
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}))
+        throw new Error(data.error || `API Error: ${response.status}`)
+      }
+
+      return await response.json()
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : 'Failed to create FPX intent'
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  /**
+   * Create a BECS Direct Debit payment intent (AUD only - Australia)
+   */
+  async function createBecsIntent(options: {
+    amount?: number
+    description?: string
+    metadata?: Record<string, string>
+  } = {}): Promise<PaymentIntentResult> {
+    loading.value = true
+    error.value = null
+
+    try {
+      const response = await fetch(`${apiUrl.value}/api/becs-intent`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(options),
+      })
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}))
+        throw new Error(data.error || `API Error: ${response.status}`)
+      }
+
+      return await response.json()
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : 'Failed to create BECS intent'
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  /**
    * Create a checkout session for Stripe hosted checkout
    */
   async function createCheckoutSession(options: {
@@ -310,6 +374,8 @@ export function useBackendApi() {
     createSepaIntent,
     createEpsIntent,
     createP24Intent,
+    createFpxIntent,
+    createBecsIntent,
     createCheckoutSession,
     createSubscription,
     createSetupIntent,

--- a/apps/docs/.vitepress/theme/index.ts
+++ b/apps/docs/.vitepress/theme/index.ts
@@ -30,6 +30,8 @@ import IbanElementExample from './components/examples/IbanElementExample.vue'
 import P24ElementExample from './components/examples/P24ElementExample.vue'
 import EpsElementExample from './components/examples/EpsElementExample.vue'
 import ExpressCheckoutExample from './components/examples/ExpressCheckoutExample.vue'
+import FpxPaymentExample from './components/examples/FpxPaymentExample.vue'
+import AuBankAccountPaymentExample from './components/examples/AuBankAccountPaymentExample.vue'
 
 // Analytics composables
 import { useScrollTracking } from './composables/useScrollTracking'
@@ -114,5 +116,7 @@ export default {
     app.component('EpsElementExample', EpsElementExample)
     app.component('ExpressCheckoutExample', ExpressCheckoutExample)
     app.component('StripeCoverage', StripeCoverage)
+    app.component('FpxPaymentExample', FpxPaymentExample)
+    app.component('AuBankAccountPaymentExample', AuBankAccountPaymentExample)
   }
 } satisfies Theme

--- a/apps/docs/api/components/stripe-au-bank-account-element.md
+++ b/apps/docs/api/components/stripe-au-bank-account-element.md
@@ -1,0 +1,469 @@
+# VueStripeAuBankAccountElement
+
+A form element for collecting Australian bank account details (BSB and account number) for BECS Direct Debit payments.
+
+::: tip When to Use
+Use VueStripeAuBankAccountElement for Australian customers. BECS Direct Debit is ideal for recurring payments and only supports AUD (Australian Dollar) currency.
+:::
+
+## What is AU Bank Account Element?
+
+AU Bank Account Element collects bank details for Australian payments:
+
+| Capability | Description |
+|------------|-------------|
+| **BSB Input** | 6-digit bank identifier with validation |
+| **Account Number** | Bank account number input |
+| **Bank Lookup** | Automatic bank/branch name from BSB |
+| **AUD Only** | Supports Australian Dollar exclusively |
+| **Direct Debit** | For recurring and one-time payments |
+
+## How It Works
+
+```mermaid
+flowchart TD
+    A["AuBankAccountElement mounts inside StripeElements"] --> B["Renders BSB & Account fields<br/>Emits @ready when mounted"]
+    B --> C["Customer enters bank details<br/>• 6-digit BSB number<br/>• Account number"]
+    C --> D["Validates and looks up bank<br/>Emits @change with bankName"]
+    D --> E{Submit with mandate?}
+    E -->|Yes| F["stripe.confirmAuBecsDebitPayment()<br/>with billing_details"]
+    F --> G["Payment initiates<br/>Status: 'processing'"]
+    G --> H["Settlement in 3-4 business days<br/>Webhook confirms result"]
+```
+
+## Usage
+
+```vue
+<template>
+  <VueStripeProvider :publishable-key="publishableKey">
+    <VueStripeElements>
+      <VueStripeAuBankAccountElement
+        :options="options"
+        @ready="onReady"
+        @change="onChange"
+      />
+    </VueStripeElements>
+  </VueStripeProvider>
+</template>
+
+<script setup>
+import {
+  VueStripeProvider,
+  VueStripeElements,
+  VueStripeAuBankAccountElement
+} from '@vue-stripe/vue-stripe'
+
+const publishableKey = import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY
+
+const options = {
+  style: {
+    base: {
+      fontSize: '16px',
+      color: '#424770'
+    }
+  },
+  iconStyle: 'solid'
+}
+
+const onReady = (element) => {
+  console.log('AU Bank Account element ready', element)
+}
+
+const onChange = (event) => {
+  console.log('Bank:', event.bankName)
+  console.log('Branch:', event.branchName)
+  console.log('Complete:', event.complete)
+}
+</script>
+```
+
+## Props
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `options` | `StripeAuBankAccountElementOptions` | No | Element configuration |
+
+### Options Object
+
+```ts
+interface StripeAuBankAccountElementOptions {
+  classes?: StripeElementClasses
+  style?: {
+    base?: StripeElementStyle
+    complete?: StripeElementStyle
+    empty?: StripeElementStyle
+    invalid?: StripeElementStyle
+  }
+  iconStyle?: 'default' | 'solid'
+  hideIcon?: boolean
+  disabled?: boolean
+}
+```
+
+### Style Properties
+
+```ts
+interface StripeElementStyle {
+  color?: string
+  fontFamily?: string
+  fontSize?: string
+  fontWeight?: string
+  iconColor?: string
+  lineHeight?: string
+  letterSpacing?: string
+  padding?: string
+  '::placeholder'?: { color?: string }
+  ':focus'?: StripeElementStyle
+  ':hover'?: StripeElementStyle
+}
+```
+
+### Icon Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `iconStyle` | `'default' \| 'solid'` | `'default'` | Style of the bank icon |
+| `hideIcon` | `boolean` | `false` | Whether to hide the icon |
+
+## Events
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `@ready` | `StripeAuBankAccountElement` | Emitted when the element is fully rendered |
+| `@change` | `StripeAuBankAccountElementChangeEvent` | Emitted when input changes |
+| `@focus` | - | Emitted when the element gains focus |
+| `@blur` | - | Emitted when the element loses focus |
+| `@escape` | - | Emitted when Escape key is pressed |
+
+### Change Event
+
+```ts
+interface StripeAuBankAccountElementChangeEvent {
+  elementType: 'auBankAccount'
+  empty: boolean
+  complete: boolean
+  bankName?: string   // Bank name from BSB lookup
+  branchName?: string // Branch name from BSB lookup
+  error?: {
+    message: string
+    type: string
+  }
+}
+```
+
+## Slots
+
+### Loading Slot
+
+Rendered while the element is initializing:
+
+```vue
+<VueStripeAuBankAccountElement>
+  <template #loading>
+    <div class="skeleton-loader">Loading...</div>
+  </template>
+</VueStripeAuBankAccountElement>
+```
+
+### Error Slot
+
+Rendered when there's an error:
+
+```vue
+<VueStripeAuBankAccountElement>
+  <template #error="{ error }">
+    <div class="error-message">{{ error }}</div>
+  </template>
+</VueStripeAuBankAccountElement>
+```
+
+## Exposed Methods
+
+Access these methods via template ref:
+
+```vue
+<script setup>
+import { ref } from 'vue'
+
+const auBankRef = ref()
+
+const focusElement = () => auBankRef.value?.focus()
+const clearElement = () => auBankRef.value?.clear()
+</script>
+
+<template>
+  <VueStripeAuBankAccountElement ref="auBankRef" />
+  <button @click="focusElement">Focus</button>
+  <button @click="clearElement">Clear</button>
+</template>
+```
+
+| Method | Description |
+|--------|-------------|
+| `focus()` | Focus the BSB field |
+| `blur()` | Blur the element |
+| `clear()` | Clear all input fields |
+
+## Exposed Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `element` | `Ref<StripeAuBankAccountElement \| null>` | The Stripe element instance |
+| `loading` | `Ref<boolean>` | Whether the element is loading |
+| `error` | `Ref<string \| null>` | Current error message |
+
+## Examples
+
+### Basic Usage
+
+```vue
+<VueStripeAuBankAccountElement
+  @change="(e) => console.log('Bank:', e.bankName)"
+/>
+```
+
+### With Icon Options
+
+```vue
+<VueStripeAuBankAccountElement
+  :options="{
+    iconStyle: 'solid',
+    hideIcon: false
+  }"
+/>
+```
+
+### With Custom Styling
+
+```vue
+<script setup>
+const options = {
+  style: {
+    base: {
+      fontSize: '16px',
+      color: '#32325d',
+      fontFamily: '"Helvetica Neue", Helvetica, sans-serif',
+      '::placeholder': {
+        color: '#aab7c4'
+      }
+    }
+  },
+  iconStyle: 'solid'
+}
+</script>
+
+<template>
+  <VueStripeAuBankAccountElement :options="options" />
+</template>
+```
+
+### Complete BECS Payment with Mandate
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import {
+  VueStripeProvider,
+  VueStripeElements,
+  VueStripeAuBankAccountElement,
+  useStripe,
+  useStripeElements
+} from '@vue-stripe/vue-stripe'
+
+const publishableKey = import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY
+const bankName = ref('')
+const isComplete = ref(false)
+const mandateAccepted = ref(false)
+
+const handleChange = (event: any) => {
+  bankName.value = event.bankName || ''
+  isComplete.value = event.complete
+}
+
+// In child component inside provider:
+const confirmPayment = async (clientSecret: string) => {
+  const { stripe } = useStripe()
+  const { elements } = useStripeElements()
+
+  const auBankElement = elements.value?.getElement('auBankAccount')
+
+  const { error, paymentIntent } = await stripe.value.confirmAuBecsDebitPayment(
+    clientSecret,
+    {
+      payment_method: {
+        au_becs_debit: auBankElement,
+        billing_details: {
+          name: 'John Smith',
+          email: 'john@example.com'
+        }
+      }
+    }
+  )
+
+  if (error) {
+    console.error(error.message)
+  } else if (paymentIntent.status === 'processing') {
+    console.log('Payment processing - settles in 3-4 business days')
+  }
+}
+</script>
+
+<template>
+  <VueStripeProvider :publishable-key="publishableKey">
+    <VueStripeElements>
+      <form @submit.prevent="confirmPayment(clientSecret)">
+        <VueStripeAuBankAccountElement @change="handleChange" />
+
+        <div v-if="bankName" class="bank-info">
+          Bank: {{ bankName }}
+        </div>
+
+        <!-- Mandate Agreement (Required) -->
+        <div class="mandate">
+          <label>
+            <input v-model="mandateAccepted" type="checkbox" />
+            I agree to the Direct Debit Request service agreement
+          </label>
+        </div>
+
+        <button :disabled="!isComplete || !mandateAccepted">
+          Pay with BECS Direct Debit
+        </button>
+      </form>
+    </VueStripeElements>
+  </VueStripeProvider>
+</template>
+```
+
+### Displaying Bank Information
+
+```vue
+<script setup>
+import { ref } from 'vue'
+
+const bankInfo = ref({
+  bankName: '',
+  branchName: ''
+})
+
+const handleChange = (event) => {
+  if (event.bankName) {
+    bankInfo.value.bankName = event.bankName
+  }
+  if (event.branchName) {
+    bankInfo.value.branchName = event.branchName
+  }
+}
+</script>
+
+<template>
+  <div>
+    <VueStripeAuBankAccountElement @change="handleChange" />
+
+    <div v-if="bankInfo.bankName" class="bank-details">
+      <p><strong>Bank:</strong> {{ bankInfo.bankName }}</p>
+      <p v-if="bankInfo.branchName">
+        <strong>Branch:</strong> {{ bankInfo.branchName }}
+      </p>
+    </div>
+  </div>
+</template>
+```
+
+## TypeScript
+
+```ts
+import { ref } from 'vue'
+import { VueStripeAuBankAccountElement } from '@vue-stripe/vue-stripe'
+import type {
+  StripeAuBankAccountElement,
+  StripeAuBankAccountElementChangeEvent,
+  StripeAuBankAccountElementOptions
+} from '@stripe/stripe-js'
+
+// Options
+const options: StripeAuBankAccountElementOptions = {
+  style: {
+    base: {
+      fontSize: '16px'
+    }
+  },
+  iconStyle: 'solid',
+  hideIcon: false
+}
+
+// Event handlers
+const handleReady = (element: StripeAuBankAccountElement) => {
+  console.log('Ready:', element)
+}
+
+const handleChange = (event: StripeAuBankAccountElementChangeEvent) => {
+  console.log('Bank:', event.bankName)
+  console.log('Branch:', event.branchName)
+  console.log('Complete:', event.complete)
+}
+
+// Template ref
+const auBankRef = ref<InstanceType<typeof VueStripeAuBankAccountElement>>()
+```
+
+## Mandate Agreement
+
+BECS Direct Debit requires displaying and collecting consent for the Direct Debit Request Service Agreement:
+
+```vue
+<template>
+  <div class="mandate-text">
+    <p>
+      By providing your bank account details and confirming this payment, you agree
+      to this Direct Debit Request and the
+      <a href="https://stripe.com/au-becs-dd-service-agreement/legal" target="_blank">
+        Direct Debit Request service agreement
+      </a>,
+      and authorise Stripe Payments Australia Pty Ltd ACN 160 180 343 Direct Debit
+      User ID number 507156 ("Stripe") to debit your account through the Bulk Electronic
+      Clearing System (BECS) on behalf of <strong>{{ businessName }}</strong>
+      (the "Merchant") for any amounts separately communicated to you by the Merchant.
+    </p>
+  </div>
+</template>
+```
+
+## Payment Status Flow
+
+| Status | Meaning | When |
+|--------|---------|------|
+| `processing` | Payment initiated | Immediately after confirm |
+| `succeeded` | Payment successful | 3-4 business days |
+| `requires_payment_method` | Payment failed | 3-4 business days |
+
+Use webhooks to track final status:
+
+```ts
+// webhook handler
+switch (event.type) {
+  case 'payment_intent.succeeded':
+    // BECS payment settled
+    break
+  case 'payment_intent.payment_failed':
+    // BECS payment failed
+    break
+}
+```
+
+## Error Handling
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `invalid_bsb` | BSB number is invalid | Verify BSB format (6 digits) |
+| `invalid_account_number` | Account number invalid | Check account number format |
+| `payment_intent_unexpected_state` | PaymentIntent not in expected state | Check PaymentIntent status |
+| `mandate_data_missing` | Missing mandate agreement | Include billing_details |
+
+## See Also
+
+- [VueStripeElements](/api/components/stripe-elements) - Parent container component
+- [useStripeElements](/api/composables/use-stripe-elements) - Access elements in child components
+- [AU Bank Account Element Guide](/guide/au-bank-account-element) - Step-by-step implementation
+- [VueStripeFpxBankElement](/api/components/stripe-fpx-bank-element) - Malaysian payments
+- [VueStripeIbanElement](/api/components/stripe-iban-element) - SEPA payments

--- a/apps/docs/api/components/stripe-fpx-bank-element.md
+++ b/apps/docs/api/components/stripe-fpx-bank-element.md
@@ -1,0 +1,414 @@
+# VueStripeFpxBankElement
+
+A dropdown selector for Malaysian banks enabling FPX (Financial Process Exchange) payments, Malaysia's national real-time online banking system.
+
+::: tip When to Use
+Use VueStripeFpxBankElement for Malaysian customers. FPX is the dominant payment method in Malaysia and only supports MYR (Malaysian Ringgit) currency.
+:::
+
+## What is FPX Bank Element?
+
+FPX Bank Element provides a bank selector for Malaysian payments:
+
+| Capability | Description |
+|------------|-------------|
+| **Bank Dropdown** | Pre-populated list of all major Malaysian banks |
+| **Account Type** | Supports both individual and business accounts |
+| **Redirect Flow** | Seamless redirect to customer's bank |
+| **MYR Only** | Supports Malaysian Ringgit exclusively |
+| **Instant Notification** | Real-time payment confirmation |
+
+## How It Works
+
+```mermaid
+flowchart TD
+    A["FpxBankElement mounts inside StripeElements"] --> B["Renders bank dropdown<br/>Emits @ready when mounted"]
+    B --> C["Customer selects bank from dropdown<br/>• Maybank, CIMB, Public Bank, etc."]
+    C --> D["Emits @change with bank code<br/>{ complete: true, value: 'maybank2u' }"]
+    D --> E{Submit form?}
+    E -->|Yes| F["stripe.confirmFpxPayment()<br/>with return_url"]
+    F --> G["REDIRECT<br/>Customer sent to bank<br/>to authorize payment"]
+    G --> H["Customer returns to return_url<br/>with payment result"]
+```
+
+## Usage
+
+```vue
+<template>
+  <VueStripeProvider :publishable-key="publishableKey">
+    <VueStripeElements>
+      <VueStripeFpxBankElement
+        account-holder-type="individual"
+        :options="options"
+        @ready="onReady"
+        @change="onChange"
+      />
+    </VueStripeElements>
+  </VueStripeProvider>
+</template>
+
+<script setup>
+import {
+  VueStripeProvider,
+  VueStripeElements,
+  VueStripeFpxBankElement
+} from '@vue-stripe/vue-stripe'
+
+const publishableKey = import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY
+
+const options = {
+  style: {
+    base: {
+      fontSize: '16px',
+      color: '#424770'
+    }
+  }
+}
+
+const onReady = (element) => {
+  console.log('FPX element ready', element)
+}
+
+const onChange = (event) => {
+  console.log('Selected bank:', event.value)
+  console.log('Complete:', event.complete)
+}
+</script>
+```
+
+## Props
+
+| Prop | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `accountHolderType` | `'individual' \| 'company'` | No | `'individual'` | Type of account holder |
+| `options` | `Omit<StripeFpxBankElementOptions, 'accountHolderType'>` | No | - | Element configuration |
+
+::: warning Required by Stripe
+The `accountHolderType` is required by Stripe's FPX implementation. It defaults to `'individual'` if not specified.
+:::
+
+### Options Object
+
+```ts
+interface StripeFpxBankElementOptions {
+  accountHolderType: 'individual' | 'company'  // Required by Stripe, handled via prop
+  style?: {
+    base?: StripeElementStyle
+    complete?: StripeElementStyle
+    empty?: StripeElementStyle
+    invalid?: StripeElementStyle
+  }
+  value?: string  // Pre-select a bank by code
+  disabled?: boolean
+}
+```
+
+### Style Properties
+
+```ts
+interface StripeElementStyle {
+  color?: string
+  fontFamily?: string
+  fontSize?: string
+  fontWeight?: string
+  iconColor?: string
+  lineHeight?: string
+  letterSpacing?: string
+  padding?: string
+  '::placeholder'?: { color?: string }
+  ':focus'?: StripeElementStyle
+  ':hover'?: StripeElementStyle
+}
+```
+
+## Events
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `@ready` | `StripeFpxBankElement` | Emitted when the element is fully rendered |
+| `@change` | `StripeFpxBankElementChangeEvent` | Emitted when bank selection changes |
+| `@focus` | - | Emitted when the element gains focus |
+| `@blur` | - | Emitted when the element loses focus |
+| `@escape` | - | Emitted when Escape key is pressed |
+
+### Change Event
+
+```ts
+interface StripeFpxBankElementChangeEvent {
+  elementType: 'fpxBank'
+  empty: boolean
+  complete: boolean
+  value: string  // Bank code: 'maybank2u', 'cimb', etc.
+}
+```
+
+### Bank Codes
+
+| Code | Bank Name |
+|------|-----------|
+| `affin_bank` | Affin Bank |
+| `agrobank` | Agrobank |
+| `alliance_bank` | Alliance Bank |
+| `ambank` | AmBank |
+| `bank_islam` | Bank Islam |
+| `bank_muamalat` | Bank Muamalat |
+| `bank_rakyat` | Bank Rakyat |
+| `bsn` | BSN (Bank Simpanan Nasional) |
+| `cimb` | CIMB Bank |
+| `hong_leong_bank` | Hong Leong Bank |
+| `hsbc` | HSBC Bank |
+| `kfh` | KFH (Kuwait Finance House) |
+| `maybank2u` | Maybank |
+| `ocbc` | OCBC Bank |
+| `public_bank` | Public Bank |
+| `rhb` | RHB Bank |
+| `standard_chartered` | Standard Chartered |
+| `uob` | UOB Bank |
+
+## Slots
+
+### Loading Slot
+
+Rendered while the element is initializing:
+
+```vue
+<VueStripeFpxBankElement account-holder-type="individual">
+  <template #loading>
+    <div class="skeleton-loader">Loading banks...</div>
+  </template>
+</VueStripeFpxBankElement>
+```
+
+### Error Slot
+
+Rendered when there's an error:
+
+```vue
+<VueStripeFpxBankElement account-holder-type="individual">
+  <template #error="{ error }">
+    <div class="error-message">{{ error }}</div>
+  </template>
+</VueStripeFpxBankElement>
+```
+
+## Exposed Methods
+
+Access these methods via template ref:
+
+```vue
+<script setup>
+import { ref } from 'vue'
+
+const fpxRef = ref()
+
+const focusElement = () => fpxRef.value?.focus()
+const clearElement = () => fpxRef.value?.clear()
+</script>
+
+<template>
+  <VueStripeFpxBankElement ref="fpxRef" account-holder-type="individual" />
+  <button @click="focusElement">Focus</button>
+  <button @click="clearElement">Clear Selection</button>
+</template>
+```
+
+| Method | Description |
+|--------|-------------|
+| `focus()` | Focus the bank selector |
+| `blur()` | Blur the bank selector |
+| `clear()` | Clear the selection |
+
+## Exposed Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `element` | `Ref<StripeFpxBankElement \| null>` | The Stripe element instance |
+| `loading` | `Ref<boolean>` | Whether the element is loading |
+| `error` | `Ref<string \| null>` | Current error message |
+
+## Examples
+
+### Basic Usage
+
+```vue
+<VueStripeFpxBankElement
+  account-holder-type="individual"
+  @change="(e) => console.log('Bank:', e.value)"
+/>
+```
+
+### For Business Accounts
+
+```vue
+<VueStripeFpxBankElement
+  account-holder-type="company"
+  @change="handleChange"
+/>
+```
+
+### With Custom Styling
+
+```vue
+<script setup>
+const options = {
+  style: {
+    base: {
+      fontSize: '16px',
+      color: '#32325d',
+      fontFamily: '"Helvetica Neue", Helvetica, sans-serif',
+      padding: '10px 12px'
+    }
+  }
+}
+</script>
+
+<template>
+  <VueStripeFpxBankElement
+    account-holder-type="individual"
+    :options="options"
+  />
+</template>
+```
+
+### Pre-selecting a Bank
+
+```vue
+<VueStripeFpxBankElement
+  account-holder-type="individual"
+  :options="{ value: 'maybank2u' }"
+/>
+```
+
+### Complete FPX Payment
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import {
+  VueStripeProvider,
+  VueStripeElements,
+  VueStripeFpxBankElement,
+  useStripe,
+  useStripeElements
+} from '@vue-stripe/vue-stripe'
+
+const publishableKey = import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY
+const selectedBank = ref('')
+const isComplete = ref(false)
+
+const handleChange = (event: any) => {
+  selectedBank.value = event.value || ''
+  isComplete.value = event.complete
+}
+
+// In child component inside provider:
+const confirmPayment = async (clientSecret: string) => {
+  const { stripe } = useStripe()
+  const { elements } = useStripeElements()
+
+  const fpxElement = elements.value?.getElement('fpxBank')
+
+  const { error } = await stripe.value.confirmFpxPayment(
+    clientSecret,
+    {
+      payment_method: {
+        fpx: fpxElement
+      },
+      return_url: `${window.location.origin}/payment-complete`
+    }
+  )
+
+  if (error) {
+    console.error(error.message)
+  }
+  // Customer redirected to bank
+}
+</script>
+
+<template>
+  <VueStripeProvider :publishable-key="publishableKey">
+    <VueStripeElements>
+      <form @submit.prevent="confirmPayment(clientSecret)">
+        <VueStripeFpxBankElement
+          account-holder-type="individual"
+          @change="handleChange"
+        />
+        <button :disabled="!isComplete">Pay with FPX</button>
+      </form>
+    </VueStripeElements>
+  </VueStripeProvider>
+</template>
+```
+
+### Handling Return URL
+
+```vue
+<script setup>
+import { onMounted, ref } from 'vue'
+import { useStripe } from '@vue-stripe/vue-stripe'
+
+const status = ref<'loading' | 'success' | 'error'>('loading')
+
+onMounted(async () => {
+  const params = new URLSearchParams(window.location.search)
+  const clientSecret = params.get('payment_intent_client_secret')
+
+  if (clientSecret) {
+    const { stripe } = useStripe()
+    const { paymentIntent } = await stripe.value.retrievePaymentIntent(clientSecret)
+
+    status.value = paymentIntent.status === 'succeeded' ? 'success' : 'error'
+  }
+})
+</script>
+```
+
+## TypeScript
+
+```ts
+import { ref } from 'vue'
+import { VueStripeFpxBankElement } from '@vue-stripe/vue-stripe'
+import type {
+  StripeFpxBankElement,
+  StripeFpxBankElementChangeEvent,
+  StripeFpxBankElementOptions
+} from '@stripe/stripe-js'
+
+// Options (without accountHolderType - use prop instead)
+const options: Omit<StripeFpxBankElementOptions, 'accountHolderType'> = {
+  style: {
+    base: {
+      fontSize: '16px'
+    }
+  }
+}
+
+// Event handlers
+const handleReady = (element: StripeFpxBankElement) => {
+  console.log('Ready:', element)
+}
+
+const handleChange = (event: StripeFpxBankElementChangeEvent) => {
+  console.log('Bank:', event.value)
+  console.log('Complete:', event.complete)
+}
+
+// Template ref
+const fpxRef = ref<InstanceType<typeof VueStripeFpxBankElement>>()
+```
+
+## Error Handling
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `payment_intent_unexpected_state` | PaymentIntent not in expected state | Check PaymentIntent status |
+| `redirect_failed` | Bank redirect failed | Retry the payment |
+| `payment_method_not_available` | FPX not available | Verify account has FPX enabled |
+
+## See Also
+
+- [VueStripeElements](/api/components/stripe-elements) - Parent container component
+- [useStripeElements](/api/composables/use-stripe-elements) - Access elements in child components
+- [FPX Bank Element Guide](/guide/fpx-bank-element) - Step-by-step implementation
+- [VueStripeAuBankAccountElement](/api/components/stripe-au-bank-account-element) - Australian payments
+- [VueStripeIdealBankElement](/api/components/stripe-ideal-bank-element) - Dutch payments

--- a/apps/docs/guide/au-bank-account-element.md
+++ b/apps/docs/guide/au-bank-account-element.md
@@ -1,0 +1,494 @@
+# AU Bank Account Element
+
+The AU Bank Account Element collects Australian bank account details (BSB and account number) for BECS Direct Debit payments. BECS (Bulk Electronic Clearing System) is Australia's primary direct debit payment system.
+
+::: tip Australia Only
+BECS Direct Debit is exclusively for Australian bank accounts. For other APAC countries, see [FPX Bank Element](/guide/fpx-bank-element) (Malaysia). For European options, see [IBAN Element](/guide/iban-element) (SEPA).
+:::
+
+## Why Use BECS Direct Debit?
+
+| Feature | Benefit |
+|---------|---------|
+| **Recurring Payments** | Ideal for subscriptions and recurring billing |
+| **Lower Fees** | Significantly lower than card transaction fees |
+| **No Expiration** | Bank accounts don't expire like cards |
+| **AUD Support** | Native Australian Dollar transactions |
+| **All Major Banks** | Works with all Australian banks |
+
+## When to Use AU Bank Account Element
+
+| Scenario | Description |
+|----------|-------------|
+| **Subscriptions** | Recurring payments for Australian customers |
+| **B2B Payments** | Business-to-business transactions |
+| **High-value transactions** | Avoid card limits and reduce fees |
+| **AUD transactions** | BECS only supports Australian Dollars |
+
+## How It Works
+
+```mermaid
+flowchart TD
+    A["AuBankAccountElement mounts inside StripeElements"] --> B["Renders BSB & Account fields<br/>Emits @ready when mounted"]
+    B --> C["Customer enters bank details<br/>• 6-digit BSB number<br/>• Account number"]
+    C --> D["Validates BSB format and bank lookup<br/>Emits @change with bankName"]
+    D --> E["On submit: Create BECS PaymentIntent"]
+    E --> F["stripe.confirmAuBecsDebitPayment()"]
+    F --> G["Payment initiates<br/>(typically settles in 3-4 business days)"]
+    G --> H["Webhook confirms settlement"]
+```
+
+## Required Components
+
+| Component | Role |
+|-----------|------|
+| `VueStripeProvider` | Loads Stripe.js and provides stripe instance |
+| `VueStripeElements` | Creates Elements instance |
+| `VueStripeAuBankAccountElement` | Renders BSB and account number fields |
+
+## Basic Implementation
+
+### Step 1: Set Up the Component
+
+```vue
+<script setup>
+import {
+  VueStripeProvider,
+  VueStripeElements,
+  VueStripeAuBankAccountElement
+} from '@vue-stripe/vue-stripe'
+
+const publishableKey = import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY
+</script>
+
+<template>
+  <VueStripeProvider :publishable-key="publishableKey">
+    <VueStripeElements>
+      <VueStripeAuBankAccountElement
+        @ready="onReady"
+        @change="onChange"
+      />
+    </VueStripeElements>
+  </VueStripeProvider>
+</template>
+```
+
+### Step 2: Handle Input Changes
+
+```vue{7-14}
+<script setup>
+import { ref } from 'vue'
+
+const isComplete = ref(false)
+const bankName = ref('')
+
+const onChange = (event) => {
+  isComplete.value = event.complete
+  if (event.bankName) {
+    bankName.value = event.bankName
+    console.log('Bank identified:', event.bankName)
+  }
+}
+</script>
+```
+
+**What's happening:**
+- The `@change` event fires as the user enters bank details
+- `event.bankName` provides the bank name (looked up from BSB)
+- `event.branchName` provides the branch name
+- `event.complete` is true when both BSB and account number are valid
+
+## Bank Identification
+
+When a valid BSB is entered, Stripe looks up the bank:
+
+| Change Event Property | Description |
+|----------------------|-------------|
+| `bankName` | Full bank name (e.g., "Commonwealth Bank of Australia") |
+| `branchName` | Branch name for the BSB |
+| `complete` | Whether both fields are valid |
+| `empty` | Whether the fields are empty |
+
+## Confirming BECS Payments
+
+BECS payments require customer agreement to the Direct Debit Request Service Agreement:
+
+### Backend Endpoint
+
+```typescript
+// POST /api/becs-intent
+import Stripe from 'stripe'
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY)
+
+export async function POST(request: Request) {
+  const { amount } = await request.json()
+
+  const paymentIntent = await stripe.paymentIntents.create({
+    amount,
+    currency: 'aud', // BECS only supports AUD
+    payment_method_types: ['au_becs_debit'],
+  })
+
+  return Response.json({
+    clientSecret: paymentIntent.client_secret
+  })
+}
+```
+
+### Frontend Confirmation
+
+```vue
+<script setup>
+import { useStripe, useStripeElements } from '@vue-stripe/vue-stripe'
+
+const { stripe } = useStripe()
+const { elements } = useStripeElements()
+
+const handleSubmit = async (clientSecret: string) => {
+  const auBankAccountElement = elements.value?.getElement('auBankAccount')
+
+  const { error, paymentIntent } = await stripe.value.confirmAuBecsDebitPayment(
+    clientSecret,
+    {
+      payment_method: {
+        au_becs_debit: auBankAccountElement,
+        billing_details: {
+          name: 'Customer Name',
+          email: 'customer@example.com'
+        }
+      }
+    }
+  )
+
+  if (error) {
+    console.error(error.message)
+  } else if (paymentIntent.status === 'processing') {
+    console.log('Payment is processing - will settle in 3-4 business days')
+  }
+}
+</script>
+```
+
+::: warning Mandate Agreement Required
+BECS Direct Debit requires displaying the Direct Debit Request Service Agreement and collecting customer consent. Include the mandate text in your payment form.
+:::
+
+## Displaying the Mandate Agreement
+
+Australian regulations require displaying the Direct Debit Request Service Agreement:
+
+```vue
+<template>
+  <div class="mandate-agreement">
+    <p>
+      By providing your bank account details and confirming this payment, you agree
+      to this Direct Debit Request and the
+      <a href="https://stripe.com/au-becs-dd-service-agreement/legal" target="_blank">
+        Direct Debit Request service agreement
+      </a>,
+      and authorise Stripe Payments Australia Pty Ltd ACN 160 180 343 Direct Debit User ID
+      number 507156 ("Stripe") to debit your account through the Bulk Electronic Clearing
+      System (BECS) on behalf of <strong>{{ businessName }}</strong> (the "Merchant") for
+      any amounts separately communicated to you by the Merchant.
+    </p>
+  </div>
+</template>
+```
+
+## Payment Settlement
+
+BECS payments don't confirm instantly like cards:
+
+| Status | Meaning | Typical Timing |
+|--------|---------|----------------|
+| `processing` | Payment initiated | Immediate |
+| `succeeded` | Payment successful | 3-4 business days |
+| `requires_payment_method` | Payment failed | 3-4 business days |
+
+Use webhooks to track the actual settlement:
+
+```typescript
+// Webhook handler
+export async function POST(request: Request) {
+  const event = await stripe.webhooks.constructEvent(/*...*/)
+
+  switch (event.type) {
+    case 'payment_intent.succeeded':
+      // BECS payment settled successfully
+      break
+    case 'payment_intent.payment_failed':
+      // BECS payment failed
+      break
+  }
+}
+```
+
+## Customization
+
+### Custom Styling
+
+```vue
+<script setup>
+const auBankOptions = {
+  style: {
+    base: {
+      fontSize: '16px',
+      color: '#424770',
+      fontFamily: '-apple-system, BlinkMacSystemFont, sans-serif',
+      '::placeholder': {
+        color: '#aab7c4'
+      }
+    }
+  },
+  iconStyle: 'solid', // or 'default'
+  hideIcon: false
+}
+</script>
+
+<template>
+  <VueStripeAuBankAccountElement :options="auBankOptions" />
+</template>
+```
+
+### Icon Options
+
+| Option | Values | Default |
+|--------|--------|---------|
+| `iconStyle` | `'default'`, `'solid'` | `'default'` |
+| `hideIcon` | `true`, `false` | `false` |
+
+## Complete Example
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import {
+  VueStripeProvider,
+  VueStripeElements,
+  VueStripeAuBankAccountElement,
+  useStripe,
+  useStripeElements
+} from '@vue-stripe/vue-stripe'
+
+const publishableKey = import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY
+
+const isComplete = ref(false)
+const bankName = ref('')
+const branchName = ref('')
+const processing = ref(false)
+const error = ref('')
+const customerName = ref('')
+const customerEmail = ref('')
+const mandateAccepted = ref(false)
+
+const businessName = 'Your Business Name'
+
+const auBankOptions = {
+  style: {
+    base: {
+      fontSize: '16px',
+      color: '#424770'
+    }
+  },
+  iconStyle: 'solid' as const
+}
+
+const handleChange = (event: any) => {
+  isComplete.value = event.complete
+  if (event.bankName) {
+    bankName.value = event.bankName
+  }
+  if (event.branchName) {
+    branchName.value = event.branchName
+  }
+}
+
+const handleSubmit = async () => {
+  if (!mandateAccepted.value) {
+    error.value = 'Please accept the Direct Debit agreement'
+    return
+  }
+
+  processing.value = true
+  error.value = ''
+
+  try {
+    // Fetch clientSecret from backend
+    const response = await fetch('/api/becs-intent', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ amount: 1000 })
+    })
+    const { clientSecret } = await response.json()
+
+    // Confirm payment (would be in child component with useStripe)
+    // ... confirm BECS payment
+  } catch (e) {
+    error.value = 'Failed to process payment'
+  } finally {
+    processing.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="becs-form">
+    <VueStripeProvider :publishable-key="publishableKey">
+      <VueStripeElements>
+        <form @submit.prevent="handleSubmit">
+          <div class="field">
+            <label>Full Name</label>
+            <input
+              v-model="customerName"
+              type="text"
+              placeholder="John Smith"
+              required
+            />
+          </div>
+
+          <div class="field">
+            <label>Email</label>
+            <input
+              v-model="customerEmail"
+              type="email"
+              placeholder="john@example.com"
+              required
+            />
+          </div>
+
+          <div class="field">
+            <label>Bank Account (BSB & Account Number)</label>
+            <VueStripeAuBankAccountElement
+              :options="auBankOptions"
+              @change="handleChange"
+            />
+          </div>
+
+          <div v-if="bankName" class="bank-info">
+            <strong>{{ bankName }}</strong>
+            <span v-if="branchName"> - {{ branchName }}</span>
+          </div>
+
+          <!-- Mandate Agreement -->
+          <div class="mandate">
+            <label class="checkbox-label">
+              <input
+                v-model="mandateAccepted"
+                type="checkbox"
+              />
+              <span>
+                By providing your bank account details and confirming this payment,
+                you agree to this Direct Debit Request and the
+                <a href="https://stripe.com/au-becs-dd-service-agreement/legal" target="_blank">
+                  Direct Debit Request service agreement
+                </a>.
+              </span>
+            </label>
+          </div>
+
+          <div v-if="error" class="error">{{ error }}</div>
+
+          <button
+            type="submit"
+            :disabled="!isComplete || !mandateAccepted || processing"
+          >
+            {{ processing ? 'Processing...' : 'Pay with BECS Direct Debit' }}
+          </button>
+
+          <p class="note">
+            BECS Direct Debit payments typically settle in 3-4 business days.
+          </p>
+        </form>
+      </VueStripeElements>
+    </VueStripeProvider>
+  </div>
+</template>
+
+<style scoped>
+.becs-form {
+  max-width: 400px;
+  margin: 0 auto;
+}
+
+.field {
+  margin-bottom: 16px;
+}
+
+.field label {
+  display: block;
+  margin-bottom: 8px;
+  font-weight: 500;
+}
+
+.field input {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  font-size: 16px;
+}
+
+.bank-info {
+  margin-bottom: 16px;
+  padding: 8px 12px;
+  background: #e8f5e9;
+  border-radius: 4px;
+  font-size: 14px;
+  color: #2e7d32;
+}
+
+.mandate {
+  margin-bottom: 16px;
+  padding: 12px;
+  background: #f5f5f5;
+  border-radius: 4px;
+  font-size: 12px;
+}
+
+.checkbox-label {
+  display: flex;
+  gap: 8px;
+  cursor: pointer;
+}
+
+.checkbox-label input {
+  width: auto;
+}
+
+button {
+  width: 100%;
+  padding: 12px;
+  background: #002d5b;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  font-size: 16px;
+  cursor: pointer;
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.error {
+  color: #9e2146;
+  margin-bottom: 16px;
+}
+
+.note {
+  margin-top: 16px;
+  font-size: 12px;
+  color: #666;
+  text-align: center;
+}
+</style>
+```
+
+## Next Steps
+
+- [FPX Bank Element](/guide/fpx-bank-element) — Malaysian bank payments
+- [IBAN Element](/guide/iban-element) — SEPA Direct Debit for EU
+- [Payment Element](/guide/payment-element) — Unified payment method selector
+- [API Reference](/api/components/stripe-au-bank-account-element) — Full props, events, and options

--- a/apps/docs/guide/fpx-bank-element.md
+++ b/apps/docs/guide/fpx-bank-element.md
@@ -1,0 +1,429 @@
+# FPX Bank Element
+
+The FPX Bank Element displays a dropdown of Malaysian banks for FPX (Financial Process Exchange) payments. FPX is Malaysia's national real-time online banking system.
+
+::: tip Malaysia Only
+FPX is exclusively for Malaysian bank customers. For other APAC countries, see [AU Bank Account Element](/guide/au-bank-account-element) (Australia). For European options, see [iDEAL](/guide/ideal-bank-element) (Netherlands) or [IBAN](/guide/iban-element) (SEPA).
+:::
+
+## Why Use FPX?
+
+| Feature | Benefit |
+|---------|---------|
+| **Market Leader** | Dominant payment method in Malaysia |
+| **Bank Coverage** | Supports 16+ Malaysian banks |
+| **Instant Confirmation** | Real-time payment notification |
+| **Lower Fees** | Typically lower than card transaction fees |
+| **MYR Transactions** | Native Malaysian Ringgit support |
+
+## When to Use FPX Element
+
+| Scenario | Description |
+|----------|-------------|
+| **Malaysian customers** | Primary payment method in Malaysia |
+| **E-commerce** | Online purchases by Malaysian shoppers |
+| **MYR transactions** | FPX only supports Malaysian Ringgit |
+
+## How It Works
+
+```mermaid
+flowchart TD
+    A["FpxBankElement mounts inside StripeElements"] --> B["Renders bank dropdown<br/>Emits @ready when mounted"]
+    B --> C["Customer selects their bank<br/>• Maybank, CIMB, Public Bank, etc."]
+    C --> D["Emits @change with selected bank code<br/>{ complete, value }"]
+    D --> E["On submit: Create FPX PaymentIntent"]
+    E --> F["stripe.confirmFpxPayment()"]
+    F --> G["Customer redirected to bank<br/>to authorize payment"]
+    G --> H["Return to your site with result"]
+```
+
+## Required Components
+
+| Component | Role |
+|-----------|------|
+| `VueStripeProvider` | Loads Stripe.js and provides stripe instance |
+| `VueStripeElements` | Creates Elements instance |
+| `VueStripeFpxBankElement` | Renders the Malaysian bank dropdown |
+
+## Basic Implementation
+
+### Step 1: Set Up the Component
+
+```vue
+<script setup>
+import {
+  VueStripeProvider,
+  VueStripeElements,
+  VueStripeFpxBankElement
+} from '@vue-stripe/vue-stripe'
+
+const publishableKey = import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY
+</script>
+
+<template>
+  <VueStripeProvider :publishable-key="publishableKey">
+    <VueStripeElements>
+      <VueStripeFpxBankElement
+        account-holder-type="individual"
+        @ready="onReady"
+        @change="onChange"
+      />
+    </VueStripeElements>
+  </VueStripeProvider>
+</template>
+```
+
+::: warning Required Prop
+The `account-holder-type` prop is required by Stripe and must be either `'individual'` or `'company'`. It defaults to `'individual'` if not specified.
+:::
+
+### Step 2: Handle Bank Selection
+
+```vue{7-12}
+<script setup>
+import { ref } from 'vue'
+
+const selectedBank = ref('')
+const isComplete = ref(false)
+
+const onChange = (event) => {
+  isComplete.value = event.complete
+  selectedBank.value = event.value || ''
+  console.log('Selected bank:', selectedBank.value)
+}
+</script>
+```
+
+**What's happening:**
+- The `@change` event fires when a bank is selected
+- `event.value` contains the bank code (e.g., `'affin_bank'`, `'maybank2u'`)
+- `event.complete` is true when a bank is selected
+
+## Supported Malaysian Banks
+
+| Bank Code | Bank Name | Type |
+|-----------|-----------|------|
+| `affin_bank` | Affin Bank | Commercial bank |
+| `agrobank` | Agrobank | Development bank |
+| `alliance_bank` | Alliance Bank | Commercial bank |
+| `ambank` | AmBank | Commercial bank |
+| `bank_islam` | Bank Islam | Islamic bank |
+| `bank_muamalat` | Bank Muamalat | Islamic bank |
+| `bank_rakyat` | Bank Rakyat | Cooperative bank |
+| `bsn` | BSN (Bank Simpanan Nasional) | National savings bank |
+| `cimb` | CIMB Bank | Commercial bank |
+| `hong_leong_bank` | Hong Leong Bank | Commercial bank |
+| `hsbc` | HSBC Bank | Foreign bank |
+| `kfh` | KFH (Kuwait Finance House) | Islamic bank |
+| `maybank2u` | Maybank | Commercial bank |
+| `ocbc` | OCBC Bank | Foreign bank |
+| `public_bank` | Public Bank | Commercial bank |
+| `rhb` | RHB Bank | Commercial bank |
+| `standard_chartered` | Standard Chartered | Foreign bank |
+| `uob` | UOB Bank | Foreign bank |
+
+## Confirming FPX Payments
+
+FPX uses a redirect flow - customers are sent to their bank to authorize the payment:
+
+### Backend Endpoint
+
+```typescript
+// POST /api/fpx-intent
+import Stripe from 'stripe'
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY)
+
+export async function POST(request: Request) {
+  const { amount, accountHolderType } = await request.json()
+
+  const paymentIntent = await stripe.paymentIntents.create({
+    amount,
+    currency: 'myr', // FPX only supports MYR
+    payment_method_types: ['fpx'],
+  })
+
+  return Response.json({
+    clientSecret: paymentIntent.client_secret
+  })
+}
+```
+
+### Frontend Confirmation
+
+```vue
+<script setup>
+import { useStripe, useStripeElements } from '@vue-stripe/vue-stripe'
+
+const { stripe } = useStripe()
+const { elements } = useStripeElements()
+
+const handleSubmit = async (clientSecret: string) => {
+  const fpxBankElement = elements.value?.getElement('fpxBank')
+
+  const { error } = await stripe.value.confirmFpxPayment(
+    clientSecret,
+    {
+      payment_method: {
+        fpx: fpxBankElement
+      },
+      return_url: `${window.location.origin}/payment-complete`
+    }
+  )
+
+  if (error) {
+    console.error(error.message)
+  }
+  // Customer is redirected to their bank
+}
+</script>
+```
+
+::: warning Redirect Required
+FPX payments require a `return_url`. After the customer authorizes at their bank, they're redirected back to your site. Check the URL parameters for the payment result.
+:::
+
+## Handling the Return
+
+After authorization, the customer returns to your `return_url`:
+
+```vue
+<script setup>
+import { onMounted } from 'vue'
+import { useStripe } from '@vue-stripe/vue-stripe'
+
+onMounted(async () => {
+  const clientSecret = new URLSearchParams(window.location.search)
+    .get('payment_intent_client_secret')
+
+  if (clientSecret) {
+    const { stripe } = useStripe()
+    const { paymentIntent } = await stripe.value.retrievePaymentIntent(clientSecret)
+
+    if (paymentIntent.status === 'succeeded') {
+      console.log('Payment successful!')
+    } else if (paymentIntent.status === 'processing') {
+      console.log('Payment is processing')
+    }
+  }
+})
+</script>
+```
+
+## Account Holder Types
+
+FPX requires specifying the account holder type:
+
+| Type | Description |
+|------|-------------|
+| `individual` | Personal banking accounts (default) |
+| `company` | Business/corporate banking accounts |
+
+```vue
+<template>
+  <!-- For personal accounts -->
+  <VueStripeFpxBankElement account-holder-type="individual" />
+
+  <!-- For business accounts -->
+  <VueStripeFpxBankElement account-holder-type="company" />
+</template>
+```
+
+## Customization
+
+### Custom Styling
+
+```vue
+<script setup>
+const fpxOptions = {
+  style: {
+    base: {
+      fontSize: '16px',
+      color: '#424770',
+      fontFamily: '-apple-system, BlinkMacSystemFont, sans-serif',
+      padding: '10px 12px'
+    }
+  }
+}
+</script>
+
+<template>
+  <VueStripeFpxBankElement
+    account-holder-type="individual"
+    :options="fpxOptions"
+  />
+</template>
+```
+
+## Complete Example
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import {
+  VueStripeProvider,
+  VueStripeElements,
+  VueStripeFpxBankElement,
+  useStripe,
+  useStripeElements
+} from '@vue-stripe/vue-stripe'
+
+const publishableKey = import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY
+
+const selectedBank = ref('')
+const isComplete = ref(false)
+const processing = ref(false)
+const error = ref('')
+const accountHolderType = ref<'individual' | 'company'>('individual')
+
+const fpxOptions = {
+  style: {
+    base: {
+      fontSize: '16px',
+      color: '#424770'
+    }
+  }
+}
+
+const handleChange = (event: any) => {
+  isComplete.value = event.complete
+  selectedBank.value = event.value || ''
+}
+
+const handleSubmit = async () => {
+  processing.value = true
+  error.value = ''
+
+  try {
+    // Fetch clientSecret from backend
+    const response = await fetch('/api/fpx-intent', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ amount: 1000 })
+    })
+    const { clientSecret } = await response.json()
+
+    // Confirm with redirect (would be in child component)
+    // const { stripe } = useStripe()
+    // const { elements } = useStripeElements()
+    // ... confirm payment with redirect
+  } catch (e) {
+    error.value = 'Failed to process payment'
+  } finally {
+    processing.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="fpx-form">
+    <VueStripeProvider :publishable-key="publishableKey">
+      <VueStripeElements>
+        <form @submit.prevent="handleSubmit">
+          <div class="field">
+            <label>Account Type</label>
+            <select v-model="accountHolderType">
+              <option value="individual">Individual</option>
+              <option value="company">Company</option>
+            </select>
+          </div>
+
+          <div class="field">
+            <label>Select your bank</label>
+            <VueStripeFpxBankElement
+              :account-holder-type="accountHolderType"
+              :options="fpxOptions"
+              @change="handleChange"
+            />
+          </div>
+
+          <div v-if="selectedBank" class="selected-bank">
+            Selected: {{ selectedBank }}
+          </div>
+
+          <div v-if="error" class="error">{{ error }}</div>
+
+          <button
+            type="submit"
+            :disabled="!isComplete || processing"
+          >
+            {{ processing ? 'Processing...' : 'Pay with FPX' }}
+          </button>
+
+          <p class="note">
+            You will be redirected to your bank to authorize the payment.
+          </p>
+        </form>
+      </VueStripeElements>
+    </VueStripeProvider>
+  </div>
+</template>
+
+<style scoped>
+.fpx-form {
+  max-width: 400px;
+  margin: 0 auto;
+}
+
+.field {
+  margin-bottom: 16px;
+}
+
+.field label {
+  display: block;
+  margin-bottom: 8px;
+  font-weight: 500;
+}
+
+.field select {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  font-size: 16px;
+}
+
+.selected-bank {
+  margin-bottom: 16px;
+  padding: 8px 12px;
+  background: #fff8e1;
+  border-radius: 4px;
+  font-size: 14px;
+}
+
+button {
+  width: 100%;
+  padding: 12px;
+  background: #1d4ed8;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  font-size: 16px;
+  cursor: pointer;
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.error {
+  color: #9e2146;
+  margin-bottom: 16px;
+}
+
+.note {
+  margin-top: 16px;
+  font-size: 12px;
+  color: #666;
+  text-align: center;
+}
+</style>
+```
+
+## Next Steps
+
+- [AU Bank Account Element](/guide/au-bank-account-element) — Australian BECS Direct Debit
+- [iDEAL Bank Element](/guide/ideal-bank-element) — Dutch bank payments
+- [Payment Element](/guide/payment-element) — Unified payment method selector
+- [API Reference](/api/components/stripe-fpx-bank-element) — Full props, events, and options

--- a/apps/docs/live-demo/becs-payment.md
+++ b/apps/docs/live-demo/becs-payment.md
@@ -1,0 +1,18 @@
+---
+title: BECS Direct Debit Example
+description: Accept BECS Direct Debit payments from customers in Australia
+---
+
+# BECS Direct Debit Example
+
+BECS (Bulk Electronic Clearing System) Direct Debit is Australia's primary direct debit payment system. This live demo shows the complete payment flow using the `VueStripeAuBankAccountElement` component.
+
+<AuBankAccountPaymentExample />
+
+::: warning Settlement Time
+BECS Direct Debit payments don't confirm instantly like cards. They typically settle in 3-4 business days. You'll need to use webhooks to track the final payment status.
+:::
+
+::: tip See Also
+For implementation details, see the [AU Bank Account Element Guide](/guide/au-bank-account-element) and [API Reference](/api/components/stripe-au-bank-account-element).
+:::

--- a/apps/docs/live-demo/fpx-payment.md
+++ b/apps/docs/live-demo/fpx-payment.md
@@ -1,0 +1,14 @@
+---
+title: FPX Payment Example
+description: Accept FPX payments from customers in Malaysia
+---
+
+# FPX Payment Example
+
+FPX (Financial Process Exchange) is Malaysia's national real-time online banking payment system. This live demo shows the complete payment flow using the `VueStripeFpxBankElement` component.
+
+<FpxPaymentExample />
+
+::: tip See Also
+For implementation details, see the [FPX Bank Element Guide](/guide/fpx-bank-element) and [API Reference](/api/components/stripe-fpx-bank-element).
+:::

--- a/apps/playground/src/App.vue
+++ b/apps/playground/src/App.vue
@@ -199,6 +199,9 @@ const navGroups = computed(() => {
     'IdealBankElement': Landmark,
     'P24BankElement': Landmark,
     'EpsBankElement': Landmark,
+    // APAC Regional Elements (v5.4.0)
+    'FpxBankElement': Landmark,
+    'AuBankAccountElement': Landmark,
     // Pricing Table (v5.3.0)
     'PricingTable': Table2,
   }
@@ -217,6 +220,10 @@ const navGroups = computed(() => {
       label: 'European Elements',
       items: [] as { name: string; path: string; icon: any }[]
     },
+    apac: {
+      label: 'APAC Elements',
+      items: [] as { name: string; path: string; icon: any }[]
+    },
     checkout: {
       label: 'Checkout',
       items: [] as { name: string; path: string; icon: any }[]
@@ -225,6 +232,8 @@ const navGroups = computed(() => {
 
   // European element route names
   const europeanElements = ['IbanElement', 'IdealBankElement', 'P24BankElement', 'EpsBankElement']
+  // APAC element route names
+  const apacElements = ['FpxBankElement', 'AuBankAccountElement']
 
   routes.forEach(route => {
     const name = String(route.name)
@@ -237,6 +246,8 @@ const navGroups = computed(() => {
       groups.checkout.items.push(item)
     } else if (europeanElements.includes(name)) {
       groups.european.items.push(item)
+    } else if (apacElements.includes(name)) {
+      groups.apac.items.push(item)
     } else {
       groups.elements.items.push(item)
     }

--- a/apps/playground/src/router.ts
+++ b/apps/playground/src/router.ts
@@ -18,6 +18,9 @@ import IbanElementView from './views/IbanElementView.vue'
 import IdealBankElementView from './views/IdealBankElementView.vue'
 import P24BankElementView from './views/P24BankElementView.vue'
 import EpsBankElementView from './views/EpsBankElementView.vue'
+// APAC Regional Elements (v5.4.0)
+import FpxBankElementView from './views/FpxBankElementView.vue'
+import AuBankAccountElementView from './views/AuBankAccountElementView.vue'
 import DocsExampleView from './views/DocsExampleView.vue'
 import DocsVerificationView from './views/DocsVerificationView.vue'
 // Payment Method Messaging element (v5.5 - #378)
@@ -186,6 +189,25 @@ export const routes: RouteRecordRaw[] = [
     meta: {
       title: 'EPS Bank Element - Vue Stripe',
       description: 'Accept EPS payments popular in Austria'
+    }
+  },
+  // APAC Regional Elements (v5.4.0)
+  {
+    path: '/stripe-fpx-bank-element',
+    name: 'FpxBankElement',
+    component: FpxBankElementView,
+    meta: {
+      title: 'FPX Bank Element - Vue Stripe',
+      description: 'Accept FPX payments popular in Malaysia'
+    }
+  },
+  {
+    path: '/stripe-au-bank-account-element',
+    name: 'AuBankAccountElement',
+    component: AuBankAccountElementView,
+    meta: {
+      title: 'AU Bank Account Element - Vue Stripe',
+      description: 'Accept BECS Direct Debit payments in Australia'
     }
   },
   {

--- a/apps/playground/src/views/AuBankAccountElementView.vue
+++ b/apps/playground/src/views/AuBankAccountElementView.vue
@@ -1,0 +1,546 @@
+<script setup lang="ts">
+import { ref, inject, computed, defineComponent, h, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { VueStripeProvider, VueStripeElements, VueStripeAuBankAccountElement, useStripe } from '@vue-stripe/vue-stripe'
+import type { StripeAuBankAccountElement as StripeAuBankAccountElementType, StripeAuBankAccountElementChangeEvent } from '@stripe/stripe-js'
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+  Alert,
+  AlertDescription,
+  Button,
+  Label,
+  Input,
+} from '@/components/ui'
+
+// Mark VueStripeElements as used (it's used in template)
+void VueStripeElements
+
+// Child component for BECS payment confirmation (needs to be inside VueStripeProvider)
+const BecsPaymentForm = defineComponent({
+  name: 'BecsPaymentForm',
+  props: {
+    clientSecret: { type: String, default: '' },
+    formComplete: { type: Boolean, default: false },
+    auBankAccountElement: { type: Object, default: null }
+  },
+  emits: ['payment-success', 'payment-error', 'log'],
+  setup(props, { emit }) {
+    const { stripe } = useStripe()
+    const processing = ref(false)
+
+    const handleConfirmPayment = async () => {
+      if (!stripe.value || !props.auBankAccountElement) {
+        emit('payment-error', 'Stripe or AU Bank Account element not ready')
+        return
+      }
+
+      if (!props.clientSecret) {
+        emit('payment-error', 'Client secret is required')
+        return
+      }
+
+      processing.value = true
+      emit('log', 'confirm', 'Starting BECS Direct Debit payment confirmation...')
+
+      try {
+        const { error, paymentIntent } = await stripe.value.confirmAuBecsDebitPayment(
+          props.clientSecret,
+          {
+            payment_method: {
+              au_becs_debit: props.auBankAccountElement,
+              billing_details: {
+                name: 'Test Customer',
+                email: 'test@example.com'
+              }
+            },
+          }
+        )
+
+        if (error) {
+          emit('payment-error', error.message || 'Payment failed')
+          emit('log', 'error', error.message || 'Payment failed')
+        } else if (paymentIntent?.status === 'succeeded' || paymentIntent?.status === 'processing') {
+          emit('payment-success', `PaymentIntent ${paymentIntent.status}!`)
+          emit('log', 'success', `PaymentIntent ${paymentIntent.id} - ${paymentIntent.status}`)
+        } else {
+          emit('log', 'info', `PaymentIntent status: ${paymentIntent?.status}`)
+        }
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : 'Confirmation failed'
+        emit('payment-error', message)
+        emit('log', 'error', message)
+      } finally {
+        processing.value = false
+      }
+    }
+
+    const canConfirm = computed(() =>
+      props.formComplete && props.clientSecret && !processing.value
+    )
+
+    return () => h('div', { class: 'mt-4 pt-4 border-t border-border' }, [
+      h(Button, {
+        class: 'w-full',
+        size: 'lg',
+        disabled: !canConfirm.value,
+        onClick: handleConfirmPayment
+      }, () => processing.value ? 'Processing...' : 'Confirm BECS Direct Debit Payment'),
+      h('p', {
+        class: 'text-muted-foreground text-xs mt-2 text-center'
+      }, 'Note: BECS Direct Debit payments are processed asynchronously'),
+      !props.clientSecret && h('p', {
+        class: 'text-muted-foreground text-sm mt-2 text-center'
+      }, 'Enter a client secret above to enable confirmation'),
+      props.clientSecret && !props.formComplete && h('p', {
+        class: 'text-muted-foreground text-sm mt-2 text-center'
+      }, 'Enter valid BSB and account number to enable confirmation')
+    ])
+  }
+})
+
+const stripeConfig = inject<{
+  publishableKey: string
+  clientSecret: string
+}>('stripeConfig')
+
+const route = useRoute()
+const router = useRouter()
+
+// Redirect status from payment processing
+const redirectStatus = ref<'succeeded' | 'failed' | null>(null)
+const paymentIntentId = ref<string | null>(null)
+
+// Check for redirect status on mount
+onMounted(() => {
+  const status = route.query.redirect_status as string | undefined
+  const piId = route.query.payment_intent as string | undefined
+
+  if (status === 'succeeded' || status === 'failed') {
+    redirectStatus.value = status
+    paymentIntentId.value = piId || null
+
+    // Log the redirect result
+    if (status === 'succeeded') {
+      log('redirect', `Payment succeeded! PaymentIntent: ${piId}`)
+    } else {
+      log('redirect', `Payment failed. PaymentIntent: ${piId}`)
+    }
+
+    // Clean up URL query params
+    router.replace({ query: {} })
+  }
+})
+
+// Dismiss redirect status alert
+const dismissRedirectStatus = () => {
+  redirectStatus.value = null
+  paymentIntentId.value = null
+}
+
+// Event log for tracking what happens
+const events = ref<{ time: string; type: string; message: string }[]>([])
+
+const log = (type: string, message: string) => {
+  const time = new Date().toLocaleTimeString()
+  events.value.unshift({ time, type, message })
+  if (events.value.length > 20) events.value.pop()
+  console.info(`[AuBankAccountElement Test] ${type}:`, message)
+}
+
+// AU Bank Account element ref for programmatic access
+const auBankAccountElementRef = ref<InstanceType<typeof VueStripeAuBankAccountElement> | null>(null)
+
+// Store the actual Stripe AU Bank Account element for confirmation
+const stripeAuBankAccountElement = ref<StripeAuBankAccountElementType | null>(null)
+
+// Payment confirmation state
+const confirmationStatus = ref<'idle' | 'success' | 'error'>('idle')
+const confirmationMessage = ref<string>('')
+
+// AU Bank Account state from change events
+const auBankAccountState = ref<{
+  complete: boolean
+  empty: boolean
+  bankName: string | null
+  branchName: string | null
+  error: string | null
+}>({
+  complete: false,
+  empty: true,
+  bankName: null,
+  branchName: null,
+  error: null
+})
+
+// Event handlers
+const handleReady = (element: StripeAuBankAccountElementType) => {
+  stripeAuBankAccountElement.value = element
+  log('ready', 'AU Bank Account element mounted and ready')
+}
+
+// Confirmation event handlers
+const handlePaymentSuccess = (message: string) => {
+  confirmationStatus.value = 'success'
+  confirmationMessage.value = message
+}
+
+const handlePaymentError = (message: string) => {
+  confirmationStatus.value = 'error'
+  confirmationMessage.value = message
+}
+
+const handleChange = (event: StripeAuBankAccountElementChangeEvent) => {
+  auBankAccountState.value = {
+    complete: event.complete,
+    empty: event.empty,
+    bankName: event.bankName || null,
+    branchName: event.branchName || null,
+    error: event.error?.message || null
+  }
+
+  if (event.error) {
+    log('error', event.error.message)
+  } else if (event.complete) {
+    log('complete', `Bank: ${event.bankName || 'Unknown'}, Branch: ${event.branchName || 'Unknown'}`)
+  } else if (!event.empty) {
+    log('change', 'Entering bank details...')
+  }
+}
+
+const handleFocus = () => {
+  log('focus', 'AU Bank Account element focused')
+}
+
+const handleBlur = () => {
+  log('blur', 'AU Bank Account element blurred')
+}
+
+const handleEscape = () => {
+  log('escape', 'Escape key pressed')
+}
+
+// Programmatic methods
+const focusAuBankAccount = () => {
+  auBankAccountElementRef.value?.focus()
+  log('action', 'Called focus()')
+}
+
+const clearAuBankAccount = () => {
+  auBankAccountElementRef.value?.clear()
+  log('action', 'Called clear()')
+}
+
+// Client secret for BECS payment confirmation
+const clientSecret = ref<string>('')
+
+// Validate client secret format
+const clientSecretStatus = computed(() => {
+  if (!clientSecret.value) {
+    return { valid: false, type: 'none', message: 'No client secret provided (required for confirming BECS payments)' }
+  }
+
+  const value = clientSecret.value.trim()
+
+  if (value.startsWith('pi_') && value.includes('_secret_')) {
+    return { valid: true, type: 'payment_intent', message: 'Valid PaymentIntent client secret' }
+  }
+
+  if (value.startsWith('seti_') && value.includes('_secret_')) {
+    return { valid: true, type: 'setup_intent', message: 'Valid SetupIntent client secret' }
+  }
+
+  return { valid: false, type: 'invalid', message: 'Invalid format. Expected pi_xxx_secret_xxx or seti_xxx_secret_xxx' }
+})
+
+// Computed for clean client secret value
+const cleanClientSecret = computed(() => clientSecret.value.trim() || undefined)
+</script>
+
+<template>
+  <div class="max-w-[900px] mx-auto flex flex-col gap-6">
+    <!-- Redirect Status Alert -->
+    <Alert
+      v-if="redirectStatus === 'succeeded'"
+      variant="default"
+      class="bg-success/10 border-success text-success"
+    >
+      <AlertDescription class="flex items-center justify-between">
+        <div>
+          <strong>Payment Succeeded!</strong>
+          <span v-if="paymentIntentId" class="ml-2 text-sm opacity-80">
+            PaymentIntent: {{ paymentIntentId }}
+          </span>
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          class="h-6 px-2 text-success hover:text-success hover:bg-success/20"
+          @click="dismissRedirectStatus"
+        >
+          Dismiss
+        </Button>
+      </AlertDescription>
+    </Alert>
+    <Alert
+      v-if="redirectStatus === 'failed'"
+      variant="destructive"
+    >
+      <AlertDescription class="flex items-center justify-between">
+        <div>
+          <strong>Payment Failed</strong>
+          <span v-if="paymentIntentId" class="ml-2 text-sm opacity-80">
+            PaymentIntent: {{ paymentIntentId }}
+          </span>
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          class="h-6 px-2"
+          @click="dismissRedirectStatus"
+        >
+          Dismiss
+        </Button>
+      </AlertDescription>
+    </Alert>
+
+    <Card>
+      <CardHeader>
+        <CardTitle>VueStripeAuBankAccountElement</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p class="text-muted-foreground mb-4">
+          The AU Bank Account Element collects BSB number and account number for BECS Direct Debit payments.
+          BECS (Bulk Electronic Clearing System) is Australia's direct debit payment system.
+        </p>
+        <p class="text-sm">
+          <a
+            href="https://vuestripe.com"
+            target="_blank"
+            class="text-primary hover:underline"
+          >
+            View full documentation →
+          </a>
+        </p>
+      </CardContent>
+    </Card>
+
+    <!-- Client Secret Input -->
+    <Card>
+      <CardHeader>
+        <CardTitle class="text-lg">
+          Client Secret
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p class="text-sm text-muted-foreground mb-4">
+          For BECS payments, you need a client secret from a PaymentIntent
+          created with <code class="bg-muted px-1 rounded">au_becs_debit</code> payment method type.
+        </p>
+
+        <div class="flex gap-3">
+          <Input
+            v-model="clientSecret"
+            type="text"
+            placeholder="pi_xxx_secret_xxx or seti_xxx_secret_xxx"
+            :class="{
+              'border-success': clientSecretStatus.valid,
+              'border-destructive': clientSecretStatus.type === 'invalid'
+            }"
+            class="flex-1 font-mono text-sm"
+          />
+          <Button
+            variant="secondary"
+            size="sm"
+            @click="clientSecret = ''"
+          >
+            Clear
+          </Button>
+        </div>
+        <div
+          class="mt-3 p-3 rounded-md text-sm"
+          :class="{
+            'bg-success/10 text-success': clientSecretStatus.valid,
+            'bg-destructive/10 text-destructive': clientSecretStatus.type === 'invalid',
+            'bg-secondary text-muted-foreground': clientSecretStatus.type === 'none'
+          }"
+        >
+          {{ clientSecretStatus.valid ? '✅ ' : clientSecretStatus.type === 'invalid' ? '❌ ' : '' }}{{ clientSecretStatus.message }}
+          <span
+            v-if="clientSecretStatus.valid"
+            class="font-medium ml-1"
+          >
+            ({{ clientSecretStatus.type === 'payment_intent' ? 'PaymentIntent' : 'SetupIntent' }})
+          </span>
+        </div>
+      </CardContent>
+    </Card>
+
+    <!-- Live Demo -->
+    <Card>
+      <CardHeader>
+        <CardTitle class="text-lg">
+          Live Demo
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Alert
+          v-if="!stripeConfig?.publishableKey"
+          variant="warning"
+        >
+          <AlertDescription>
+            No Stripe key configured. Click <strong>"Add Key"</strong> in the header above.
+          </AlertDescription>
+        </Alert>
+
+        <div
+          v-else
+          class="bg-secondary rounded-lg p-6"
+        >
+          <VueStripeProvider :publishable-key="stripeConfig.publishableKey">
+            <VueStripeElements :client-secret="cleanClientSecret">
+              <template #loading>
+                <div class="text-center py-8">
+                  <div class="w-12 h-12 border-3 border-border border-t-primary rounded-full animate-spin mx-auto mb-4" />
+                  <p class="text-muted-foreground">
+                    Initializing Stripe Elements...
+                  </p>
+                </div>
+              </template>
+
+              <div class="bg-card rounded-lg p-6 shadow-sm">
+                <Label class="mb-2 block">Bank Account Details (BECS - Australia)</Label>
+                <div class="stripe-element-wrapper">
+                  <VueStripeAuBankAccountElement
+                    ref="auBankAccountElementRef"
+                    @ready="handleReady"
+                    @change="handleChange"
+                    @focus="handleFocus"
+                    @blur="handleBlur"
+                    @escape="handleEscape"
+                  />
+                </div>
+
+                <!-- AU Bank Account State Display -->
+                <div class="flex flex-wrap gap-4 mt-4 p-3 bg-secondary rounded-md text-sm">
+                  <div class="flex gap-2">
+                    <span class="text-muted-foreground">Complete:</span>
+                    <span :class="auBankAccountState.complete ? 'text-success' : ''">
+                      {{ auBankAccountState.complete ? '✅ Yes' : '❌ No' }}
+                    </span>
+                  </div>
+                  <div class="flex gap-2">
+                    <span class="text-muted-foreground">Empty:</span>
+                    <span>{{ auBankAccountState.empty ? 'Yes' : 'No' }}</span>
+                  </div>
+                  <div class="flex gap-2">
+                    <span class="text-muted-foreground">Bank:</span>
+                    <span>{{ auBankAccountState.bankName || '-' }}</span>
+                  </div>
+                  <div class="flex gap-2">
+                    <span class="text-muted-foreground">Branch:</span>
+                    <span>{{ auBankAccountState.branchName || '-' }}</span>
+                  </div>
+                  <div
+                    v-if="auBankAccountState.error"
+                    class="w-full text-destructive mt-2"
+                  >
+                    <span class="text-muted-foreground">Error:</span>
+                    <span>{{ auBankAccountState.error }}</span>
+                  </div>
+                </div>
+
+                <!-- Test Data -->
+                <div class="mt-4 p-3 bg-muted/50 rounded-md text-sm">
+                  <p class="font-medium mb-2">Test BSB & Account Numbers:</p>
+                  <ul class="space-y-1 text-muted-foreground">
+                    <li>BSB: <code class="bg-muted px-1 rounded">000-000</code></li>
+                    <li>Account: <code class="bg-muted px-1 rounded">000123456</code></li>
+                  </ul>
+                </div>
+
+                <!-- Action Buttons -->
+                <div class="flex flex-wrap gap-2 mt-4">
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    @click="focusAuBankAccount"
+                  >
+                    Focus
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    @click="clearAuBankAccount"
+                  >
+                    Clear
+                  </Button>
+                </div>
+
+                <!-- Confirmation Form -->
+                <BecsPaymentForm
+                  :client-secret="cleanClientSecret || ''"
+                  :form-complete="auBankAccountState.complete"
+                  :au-bank-account-element="stripeAuBankAccountElement"
+                  @payment-success="handlePaymentSuccess"
+                  @payment-error="handlePaymentError"
+                  @log="log"
+                />
+
+                <!-- Confirmation Status -->
+                <Alert
+                  v-if="confirmationStatus === 'success'"
+                  variant="default"
+                  class="mt-4 bg-success/10 border-success text-success"
+                >
+                  <AlertDescription>
+                    {{ confirmationMessage }}
+                  </AlertDescription>
+                </Alert>
+                <Alert
+                  v-if="confirmationStatus === 'error'"
+                  variant="destructive"
+                  class="mt-4"
+                >
+                  <AlertDescription>
+                    {{ confirmationMessage }}
+                  </AlertDescription>
+                </Alert>
+              </div>
+            </VueStripeElements>
+          </VueStripeProvider>
+        </div>
+      </CardContent>
+    </Card>
+
+    <!-- Event Log -->
+    <Card>
+      <CardHeader>
+        <CardTitle class="text-lg">
+          Event Log
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div class="event-log">
+          <div
+            v-if="events.length === 0"
+            class="text-slate-400 text-center py-4"
+          >
+            No events yet. Enter bank details to see events.
+          </div>
+          <div
+            v-for="(event, index) in events"
+            :key="index"
+            class="event-entry"
+          >
+            <span class="event-time">{{ event.time }}</span>
+            <span :class="['event-type', event.type]">{{ event.type }}</span>
+            <span class="event-data">{{ event.message }}</span>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  </div>
+</template>

--- a/apps/playground/src/views/FpxBankElementView.vue
+++ b/apps/playground/src/views/FpxBankElementView.vue
@@ -1,0 +1,523 @@
+<script setup lang="ts">
+import { ref, inject, computed, defineComponent, h, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { VueStripeProvider, VueStripeElements, VueStripeFpxBankElement, useStripe } from '@vue-stripe/vue-stripe'
+import type { StripeFpxBankElement as StripeFpxBankElementType, StripeFpxBankElementChangeEvent } from '@stripe/stripe-js'
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+  Alert,
+  AlertDescription,
+  Button,
+  Label,
+  Input,
+} from '@/components/ui'
+
+// Mark VueStripeElements as used (it's used in template)
+void VueStripeElements
+
+// Child component for FPX payment confirmation (needs to be inside VueStripeProvider)
+const FpxPaymentForm = defineComponent({
+  name: 'FpxPaymentForm',
+  props: {
+    clientSecret: { type: String, default: '' },
+    bankComplete: { type: Boolean, default: false },
+    fpxElement: { type: Object, default: null }
+  },
+  emits: ['payment-success', 'payment-error', 'log'],
+  setup(props, { emit }) {
+    const { stripe } = useStripe()
+    const processing = ref(false)
+
+    const handleConfirmPayment = async () => {
+      if (!stripe.value || !props.fpxElement) {
+        emit('payment-error', 'Stripe or FPX element not ready')
+        return
+      }
+
+      if (!props.clientSecret) {
+        emit('payment-error', 'Client secret is required')
+        return
+      }
+
+      processing.value = true
+      emit('log', 'confirm', 'Starting FPX payment confirmation...')
+
+      try {
+        const { error, paymentIntent } = await stripe.value.confirmFpxPayment(
+          props.clientSecret,
+          {
+            payment_method: {
+              fpx: props.fpxElement,
+            },
+            return_url: window.location.href
+          }
+        )
+
+        if (error) {
+          emit('payment-error', error.message || 'Payment failed')
+          emit('log', 'error', error.message || 'Payment failed')
+        } else if (paymentIntent?.status === 'succeeded' || paymentIntent?.status === 'requires_action') {
+          emit('payment-success', `PaymentIntent ${paymentIntent.status}!`)
+          emit('log', 'success', `PaymentIntent ${paymentIntent.id} - ${paymentIntent.status}`)
+        } else {
+          emit('log', 'info', `PaymentIntent status: ${paymentIntent?.status}`)
+        }
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : 'Confirmation failed'
+        emit('payment-error', message)
+        emit('log', 'error', message)
+      } finally {
+        processing.value = false
+      }
+    }
+
+    const canConfirm = computed(() =>
+      props.bankComplete && props.clientSecret && !processing.value
+    )
+
+    return () => h('div', { class: 'mt-4 pt-4 border-t border-border' }, [
+      h(Button, {
+        class: 'w-full',
+        size: 'lg',
+        disabled: !canConfirm.value,
+        onClick: handleConfirmPayment
+      }, () => processing.value ? 'Processing...' : 'Confirm FPX Payment'),
+      h('p', {
+        class: 'text-muted-foreground text-xs mt-2 text-center'
+      }, 'Note: FPX payments require a redirect to the bank for authorization'),
+      !props.clientSecret && h('p', {
+        class: 'text-muted-foreground text-sm mt-2 text-center'
+      }, 'Enter a client secret above to enable confirmation'),
+      props.clientSecret && !props.bankComplete && h('p', {
+        class: 'text-muted-foreground text-sm mt-2 text-center'
+      }, 'Select a bank to enable confirmation')
+    ])
+  }
+})
+
+const stripeConfig = inject<{
+  publishableKey: string
+  clientSecret: string
+}>('stripeConfig')
+
+const route = useRoute()
+const router = useRouter()
+
+// Redirect status from bank authorization
+const redirectStatus = ref<'succeeded' | 'failed' | null>(null)
+const paymentIntentId = ref<string | null>(null)
+
+// Check for redirect status on mount
+onMounted(() => {
+  const status = route.query.redirect_status as string | undefined
+  const piId = route.query.payment_intent as string | undefined
+
+  if (status === 'succeeded' || status === 'failed') {
+    redirectStatus.value = status
+    paymentIntentId.value = piId || null
+
+    // Log the redirect result
+    if (status === 'succeeded') {
+      log('redirect', `Payment succeeded! PaymentIntent: ${piId}`)
+    } else {
+      log('redirect', `Payment failed. PaymentIntent: ${piId}`)
+    }
+
+    // Clean up URL query params
+    router.replace({ query: {} })
+  }
+})
+
+// Dismiss redirect status alert
+const dismissRedirectStatus = () => {
+  redirectStatus.value = null
+  paymentIntentId.value = null
+}
+
+// Event log for tracking what happens
+const events = ref<{ time: string; type: string; message: string }[]>([])
+
+const log = (type: string, message: string) => {
+  const time = new Date().toLocaleTimeString()
+  events.value.unshift({ time, type, message })
+  if (events.value.length > 20) events.value.pop()
+  console.info(`[FpxBankElement Test] ${type}:`, message)
+}
+
+// FPX element ref for programmatic access
+const fpxElementRef = ref<InstanceType<typeof VueStripeFpxBankElement> | null>(null)
+
+// Store the actual Stripe FPX element for confirmation
+const stripeFpxElement = ref<StripeFpxBankElementType | null>(null)
+
+// Payment confirmation state
+const confirmationStatus = ref<'idle' | 'success' | 'error'>('idle')
+const confirmationMessage = ref<string>('')
+
+// FPX state from change events
+const fpxState = ref<{
+  complete: boolean
+  empty: boolean
+  value: string | null
+  error: string | null
+}>({
+  complete: false,
+  empty: true,
+  value: null,
+  error: null
+})
+
+// Event handlers
+const handleReady = (element: StripeFpxBankElementType) => {
+  stripeFpxElement.value = element
+  log('ready', 'FPX bank element mounted and ready')
+}
+
+// Confirmation event handlers
+const handlePaymentSuccess = (message: string) => {
+  confirmationStatus.value = 'success'
+  confirmationMessage.value = message
+}
+
+const handlePaymentError = (message: string) => {
+  confirmationStatus.value = 'error'
+  confirmationMessage.value = message
+}
+
+const handleChange = (event: StripeFpxBankElementChangeEvent) => {
+  fpxState.value = {
+    complete: event.complete,
+    empty: event.empty,
+    value: event.value || null,
+    error: event.error?.message || null
+  }
+
+  if (event.error) {
+    log('error', event.error.message)
+  } else if (event.complete) {
+    log('complete', `Bank selected: ${event.value}`)
+  } else if (!event.empty) {
+    log('change', 'Selecting bank...')
+  }
+}
+
+const handleFocus = () => {
+  log('focus', 'FPX element focused')
+}
+
+const handleBlur = () => {
+  log('blur', 'FPX element blurred')
+}
+
+const handleEscape = () => {
+  log('escape', 'Escape key pressed')
+}
+
+// Programmatic methods
+const focusFpx = () => {
+  fpxElementRef.value?.focus()
+  log('action', 'Called focus()')
+}
+
+const clearFpx = () => {
+  fpxElementRef.value?.clear()
+  log('action', 'Called clear()')
+}
+
+// Client secret for FPX payment confirmation
+const clientSecret = ref<string>('')
+
+// Validate client secret format
+const clientSecretStatus = computed(() => {
+  if (!clientSecret.value) {
+    return { valid: false, type: 'none', message: 'No client secret provided (required for confirming FPX payments)' }
+  }
+
+  const value = clientSecret.value.trim()
+
+  if (value.startsWith('pi_') && value.includes('_secret_')) {
+    return { valid: true, type: 'payment_intent', message: 'Valid PaymentIntent client secret' }
+  }
+
+  return { valid: false, type: 'invalid', message: 'Invalid format. Expected pi_xxx_secret_xxx' }
+})
+
+// Computed for clean client secret value
+const cleanClientSecret = computed(() => clientSecret.value.trim() || undefined)
+</script>
+
+<template>
+  <div class="max-w-[900px] mx-auto flex flex-col gap-6">
+    <!-- Redirect Status Alert -->
+    <Alert
+      v-if="redirectStatus === 'succeeded'"
+      variant="default"
+      class="bg-success/10 border-success text-success"
+    >
+      <AlertDescription class="flex items-center justify-between">
+        <div>
+          <strong>Payment Succeeded!</strong>
+          <span v-if="paymentIntentId" class="ml-2 text-sm opacity-80">
+            PaymentIntent: {{ paymentIntentId }}
+          </span>
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          class="h-6 px-2 text-success hover:text-success hover:bg-success/20"
+          @click="dismissRedirectStatus"
+        >
+          Dismiss
+        </Button>
+      </AlertDescription>
+    </Alert>
+    <Alert
+      v-if="redirectStatus === 'failed'"
+      variant="destructive"
+    >
+      <AlertDescription class="flex items-center justify-between">
+        <div>
+          <strong>Payment Failed</strong>
+          <span v-if="paymentIntentId" class="ml-2 text-sm opacity-80">
+            PaymentIntent: {{ paymentIntentId }}
+          </span>
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          class="h-6 px-2"
+          @click="dismissRedirectStatus"
+        >
+          Dismiss
+        </Button>
+      </AlertDescription>
+    </Alert>
+
+    <Card>
+      <CardHeader>
+        <CardTitle>VueStripeFpxBankElement</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p class="text-muted-foreground mb-4">
+          The FPX Bank Element displays a dropdown list of Malaysian banks for FPX payments.
+          FPX (Financial Process Exchange) is Malaysia's national real-time online banking system.
+        </p>
+        <p class="text-sm">
+          <a
+            href="https://vuestripe.com"
+            target="_blank"
+            class="text-primary hover:underline"
+          >
+            View full documentation →
+          </a>
+        </p>
+      </CardContent>
+    </Card>
+
+    <!-- Client Secret Input -->
+    <Card>
+      <CardHeader>
+        <CardTitle class="text-lg">
+          Client Secret
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p class="text-sm text-muted-foreground mb-4">
+          For FPX payments, you need a client secret from a PaymentIntent
+          created with <code class="bg-muted px-1 rounded">fpx</code> payment method type.
+        </p>
+
+        <div class="flex gap-3">
+          <Input
+            v-model="clientSecret"
+            type="text"
+            placeholder="pi_xxx_secret_xxx"
+            :class="{
+              'border-success': clientSecretStatus.valid,
+              'border-destructive': clientSecretStatus.type === 'invalid'
+            }"
+            class="flex-1 font-mono text-sm"
+          />
+          <Button
+            variant="secondary"
+            size="sm"
+            @click="clientSecret = ''"
+          >
+            Clear
+          </Button>
+        </div>
+        <div
+          class="mt-3 p-3 rounded-md text-sm"
+          :class="{
+            'bg-success/10 text-success': clientSecretStatus.valid,
+            'bg-destructive/10 text-destructive': clientSecretStatus.type === 'invalid',
+            'bg-secondary text-muted-foreground': clientSecretStatus.type === 'none'
+          }"
+        >
+          {{ clientSecretStatus.valid ? '✅ ' : clientSecretStatus.type === 'invalid' ? '❌ ' : '' }}{{ clientSecretStatus.message }}
+          <span
+            v-if="clientSecretStatus.valid"
+            class="font-medium ml-1"
+          >
+            (PaymentIntent)
+          </span>
+        </div>
+      </CardContent>
+    </Card>
+
+    <!-- Live Demo -->
+    <Card>
+      <CardHeader>
+        <CardTitle class="text-lg">
+          Live Demo
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Alert
+          v-if="!stripeConfig?.publishableKey"
+          variant="warning"
+        >
+          <AlertDescription>
+            No Stripe key configured. Click <strong>"Add Key"</strong> in the header above.
+          </AlertDescription>
+        </Alert>
+
+        <div
+          v-else
+          class="bg-secondary rounded-lg p-6"
+        >
+          <VueStripeProvider :publishable-key="stripeConfig.publishableKey">
+            <VueStripeElements :client-secret="cleanClientSecret">
+              <template #loading>
+                <div class="text-center py-8">
+                  <div class="w-12 h-12 border-3 border-border border-t-primary rounded-full animate-spin mx-auto mb-4" />
+                  <p class="text-muted-foreground">
+                    Initializing Stripe Elements...
+                  </p>
+                </div>
+              </template>
+
+              <div class="bg-card rounded-lg p-6 shadow-sm">
+                <Label class="mb-2 block">Select your bank (FPX - Malaysia)</Label>
+                <div class="stripe-element-wrapper">
+                  <VueStripeFpxBankElement
+                    ref="fpxElementRef"
+                    @ready="handleReady"
+                    @change="handleChange"
+                    @focus="handleFocus"
+                    @blur="handleBlur"
+                    @escape="handleEscape"
+                  />
+                </div>
+
+                <!-- FPX State Display -->
+                <div class="flex flex-wrap gap-4 mt-4 p-3 bg-secondary rounded-md text-sm">
+                  <div class="flex gap-2">
+                    <span class="text-muted-foreground">Complete:</span>
+                    <span :class="fpxState.complete ? 'text-success' : ''">
+                      {{ fpxState.complete ? '✅ Yes' : '❌ No' }}
+                    </span>
+                  </div>
+                  <div class="flex gap-2">
+                    <span class="text-muted-foreground">Empty:</span>
+                    <span>{{ fpxState.empty ? 'Yes' : 'No' }}</span>
+                  </div>
+                  <div class="flex gap-2">
+                    <span class="text-muted-foreground">Selected Bank:</span>
+                    <span>{{ fpxState.value || '-' }}</span>
+                  </div>
+                  <div
+                    v-if="fpxState.error"
+                    class="w-full text-destructive mt-2"
+                  >
+                    <span class="text-muted-foreground">Error:</span>
+                    <span>{{ fpxState.error }}</span>
+                  </div>
+                </div>
+
+                <!-- Action Buttons -->
+                <div class="flex flex-wrap gap-2 mt-4">
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    @click="focusFpx"
+                  >
+                    Focus
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    @click="clearFpx"
+                  >
+                    Clear
+                  </Button>
+                </div>
+
+                <!-- Confirmation Form -->
+                <FpxPaymentForm
+                  :client-secret="cleanClientSecret || ''"
+                  :bank-complete="fpxState.complete"
+                  :fpx-element="stripeFpxElement"
+                  @payment-success="handlePaymentSuccess"
+                  @payment-error="handlePaymentError"
+                  @log="log"
+                />
+
+                <!-- Confirmation Status -->
+                <Alert
+                  v-if="confirmationStatus === 'success'"
+                  variant="default"
+                  class="mt-4 bg-success/10 border-success text-success"
+                >
+                  <AlertDescription>
+                    {{ confirmationMessage }}
+                  </AlertDescription>
+                </Alert>
+                <Alert
+                  v-if="confirmationStatus === 'error'"
+                  variant="destructive"
+                  class="mt-4"
+                >
+                  <AlertDescription>
+                    {{ confirmationMessage }}
+                  </AlertDescription>
+                </Alert>
+              </div>
+            </VueStripeElements>
+          </VueStripeProvider>
+        </div>
+      </CardContent>
+    </Card>
+
+    <!-- Event Log -->
+    <Card>
+      <CardHeader>
+        <CardTitle class="text-lg">
+          Event Log
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div class="event-log">
+          <div
+            v-if="events.length === 0"
+            class="text-slate-400 text-center py-4"
+          >
+            No events yet. Interact with the bank selector to see events.
+          </div>
+          <div
+            v-for="(event, index) in events"
+            :key="index"
+            class="event-entry"
+          >
+            <span class="event-time">{{ event.time }}</span>
+            <span :class="['event-type', event.type]">{{ event.type }}</span>
+            <span class="event-data">{{ event.message }}</span>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  </div>
+</template>

--- a/packages/vue-stripe/src/components/VueStripeAuBankAccountElement.vue
+++ b/packages/vue-stripe/src/components/VueStripeAuBankAccountElement.vue
@@ -1,0 +1,218 @@
+<script setup lang="ts">
+import { ref, inject, onMounted, onUnmounted, watch } from 'vue-demi'
+import type {
+  StripeAuBankAccountElement as StripeAuBankAccountElementType,
+  StripeAuBankAccountElementOptions,
+  StripeAuBankAccountElementChangeEvent
+} from '@stripe/stripe-js'
+import { stripeElementsInjectionKey } from '../utils/injection-keys'
+import { VueStripeElementsError } from '../utils/errors'
+
+interface Props {
+  options?: StripeAuBankAccountElementOptions
+}
+
+interface Emits {
+  (e: 'ready', element: StripeAuBankAccountElementType): void
+  (e: 'change', event: StripeAuBankAccountElementChangeEvent): void
+  (e: 'focus'): void
+  (e: 'blur'): void
+  (e: 'escape'): void
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<Emits>()
+
+const elementRef = ref<HTMLDivElement>()
+const auBankAccountElement = ref<StripeAuBankAccountElementType | null>(null)
+const loading = ref(true)
+const error = ref<string | null>(null)
+
+const elementsInstance = inject(stripeElementsInjectionKey)
+
+if (!elementsInstance) {
+  throw new VueStripeElementsError(
+    'VueStripeAuBankAccountElement must be used within VueStripeElements'
+  )
+}
+
+const createAuBankAccountElement = () => {
+  if (!elementsInstance.elements.value) {
+    error.value = 'Elements instance not available'
+    loading.value = false
+    return
+  }
+
+  if (!elementRef.value) {
+    error.value = 'Mount point not available'
+    loading.value = false
+    return
+  }
+
+  try {
+    error.value = null
+    loading.value = true
+
+    // Create AU Bank Account element
+    auBankAccountElement.value = elementsInstance.elements.value.create('auBankAccount', props.options)
+
+    // Set up event listeners
+    auBankAccountElement.value.on('ready', () => {
+      loading.value = false
+      emit('ready', auBankAccountElement.value!)
+    })
+
+    auBankAccountElement.value.on('change', (event) => {
+      // Update error state from Stripe
+      if (event.error) {
+        error.value = event.error.message
+      } else {
+        error.value = null
+      }
+      emit('change', event)
+    })
+
+    auBankAccountElement.value.on('focus', () => {
+      emit('focus')
+    })
+
+    auBankAccountElement.value.on('blur', () => {
+      emit('blur')
+    })
+
+    auBankAccountElement.value.on('escape', () => {
+      emit('escape')
+    })
+
+    // Mount the element
+    auBankAccountElement.value.mount(elementRef.value)
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : 'Failed to create AU Bank Account element'
+    error.value = errorMessage
+    loading.value = false
+    console.error('[Vue Stripe] AU Bank Account element creation error:', errorMessage)
+  }
+}
+
+// Watch for options changes
+watch(
+  () => props.options,
+  (newOptions) => {
+    if (auBankAccountElement.value && newOptions) {
+      auBankAccountElement.value.update(newOptions)
+    }
+  },
+  { deep: true }
+)
+
+// Watch for elements instance to become available
+watch(
+  () => elementsInstance.elements.value,
+  (newElements) => {
+    if (newElements && elementRef.value && !auBankAccountElement.value) {
+      createAuBankAccountElement()
+    }
+  },
+  { immediate: true }
+)
+
+onMounted(() => {
+  if (elementsInstance.elements.value && elementRef.value && !auBankAccountElement.value) {
+    createAuBankAccountElement()
+  }
+})
+
+onUnmounted(() => {
+  if (auBankAccountElement.value) {
+    auBankAccountElement.value.destroy()
+  }
+})
+
+// Expose element and methods for parent access
+defineExpose({
+  element: auBankAccountElement,
+  loading,
+  error,
+  focus: () => auBankAccountElement.value?.focus(),
+  blur: () => auBankAccountElement.value?.blur(),
+  clear: () => auBankAccountElement.value?.clear()
+})
+</script>
+
+<template>
+  <div class="vue-stripe-au-bank-account-element">
+    <div
+      v-if="error"
+      class="vue-stripe-au-bank-account-element-error"
+    >
+      <slot
+        name="error"
+        :error="error"
+      >
+        <div class="vue-stripe-error-message">
+          {{ error }}
+        </div>
+      </slot>
+    </div>
+    <div
+      ref="elementRef"
+      class="vue-stripe-au-bank-account-element-mount"
+      :class="{ 'vue-stripe-au-bank-account-element-loading': loading }"
+    />
+    <div
+      v-if="loading"
+      class="vue-stripe-au-bank-account-element-loader"
+    >
+      <slot name="loading">
+        <div class="vue-stripe-loading-message">
+          Loading BECS Direct Debit form...
+        </div>
+      </slot>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.vue-stripe-au-bank-account-element {
+  position: relative;
+}
+
+.vue-stripe-au-bank-account-element-mount {
+  padding: 12px;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  background-color: white;
+  transition: all 0.3s ease;
+  min-height: 44px;
+}
+
+.vue-stripe-au-bank-account-element-mount:focus-within {
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.vue-stripe-au-bank-account-element-loading {
+  opacity: 0.5;
+}
+
+.vue-stripe-au-bank-account-element-error {
+  color: #dc3545;
+  padding: 0.5rem 0;
+  font-size: 0.875rem;
+}
+
+.vue-stripe-au-bank-account-element-loader {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: #6c757d;
+  text-align: center;
+}
+
+.vue-stripe-error-message,
+.vue-stripe-loading-message {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+</style>

--- a/packages/vue-stripe/src/components/VueStripeFpxBankElement.vue
+++ b/packages/vue-stripe/src/components/VueStripeFpxBankElement.vue
@@ -1,0 +1,233 @@
+<script setup lang="ts">
+import { ref, inject, onMounted, onUnmounted, watch } from 'vue-demi'
+import type {
+  StripeFpxBankElement as StripeFpxBankElementType,
+  StripeFpxBankElementOptions,
+  StripeFpxBankElementChangeEvent
+} from '@stripe/stripe-js'
+import { stripeElementsInjectionKey } from '../utils/injection-keys'
+import { VueStripeElementsError } from '../utils/errors'
+
+interface Props {
+  /**
+   * The type of the FPX account holder. This is required by Stripe.
+   * @default 'individual'
+   */
+  accountHolderType?: 'individual' | 'company'
+  /**
+   * Additional options for the FPX Bank Element
+   */
+  options?: Omit<StripeFpxBankElementOptions, 'accountHolderType'>
+}
+
+interface Emits {
+  (e: 'ready', element: StripeFpxBankElementType): void
+  (e: 'change', event: StripeFpxBankElementChangeEvent): void
+  (e: 'focus'): void
+  (e: 'blur'): void
+  (e: 'escape'): void
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<Emits>()
+
+const elementRef = ref<HTMLDivElement>()
+const fpxBankElement = ref<StripeFpxBankElementType | null>(null)
+const loading = ref(true)
+const error = ref<string | null>(null)
+
+const elementsInstance = inject(stripeElementsInjectionKey)
+
+if (!elementsInstance) {
+  throw new VueStripeElementsError(
+    'VueStripeFpxBankElement must be used within VueStripeElements'
+  )
+}
+
+const createFpxBankElement = () => {
+  if (!elementsInstance.elements.value) {
+    error.value = 'Elements instance not available'
+    loading.value = false
+    return
+  }
+
+  if (!elementRef.value) {
+    error.value = 'Mount point not available'
+    loading.value = false
+    return
+  }
+
+  try {
+    error.value = null
+    loading.value = true
+
+    // Create FPX bank element with required accountHolderType
+    const fpxOptions: StripeFpxBankElementOptions = {
+      ...props.options,
+      accountHolderType: props.accountHolderType ?? 'individual'
+    }
+    fpxBankElement.value = elementsInstance.elements.value.create('fpxBank', fpxOptions)
+
+    // Set up event listeners
+    fpxBankElement.value.on('ready', () => {
+      loading.value = false
+      emit('ready', fpxBankElement.value!)
+    })
+
+    fpxBankElement.value.on('change', (event) => {
+      // Update error state from Stripe
+      if (event.error) {
+        error.value = event.error.message
+      } else {
+        error.value = null
+      }
+      emit('change', event)
+    })
+
+    fpxBankElement.value.on('focus', () => {
+      emit('focus')
+    })
+
+    fpxBankElement.value.on('blur', () => {
+      emit('blur')
+    })
+
+    fpxBankElement.value.on('escape', () => {
+      emit('escape')
+    })
+
+    // Mount the element
+    fpxBankElement.value.mount(elementRef.value)
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : 'Failed to create FPX bank element'
+    error.value = errorMessage
+    loading.value = false
+    console.error('[Vue Stripe] FPX bank element creation error:', errorMessage)
+  }
+}
+
+// Watch for options changes
+watch(
+  [() => props.options, () => props.accountHolderType],
+  ([newOptions, newAccountHolderType]) => {
+    if (fpxBankElement.value) {
+      fpxBankElement.value.update({
+        ...newOptions,
+        accountHolderType: newAccountHolderType ?? 'individual'
+      })
+    }
+  },
+  { deep: true }
+)
+
+// Watch for elements instance to become available
+watch(
+  () => elementsInstance.elements.value,
+  (newElements) => {
+    if (newElements && elementRef.value && !fpxBankElement.value) {
+      createFpxBankElement()
+    }
+  },
+  { immediate: true }
+)
+
+onMounted(() => {
+  if (elementsInstance.elements.value && elementRef.value && !fpxBankElement.value) {
+    createFpxBankElement()
+  }
+})
+
+onUnmounted(() => {
+  if (fpxBankElement.value) {
+    fpxBankElement.value.destroy()
+  }
+})
+
+// Expose element and methods for parent access
+defineExpose({
+  element: fpxBankElement,
+  loading,
+  error,
+  focus: () => fpxBankElement.value?.focus(),
+  blur: () => fpxBankElement.value?.blur(),
+  clear: () => fpxBankElement.value?.clear()
+})
+</script>
+
+<template>
+  <div class="vue-stripe-fpx-bank-element">
+    <div
+      v-if="error"
+      class="vue-stripe-fpx-bank-element-error"
+    >
+      <slot
+        name="error"
+        :error="error"
+      >
+        <div class="vue-stripe-error-message">
+          {{ error }}
+        </div>
+      </slot>
+    </div>
+    <div
+      ref="elementRef"
+      class="vue-stripe-fpx-bank-element-mount"
+      :class="{ 'vue-stripe-fpx-bank-element-loading': loading }"
+    />
+    <div
+      v-if="loading"
+      class="vue-stripe-fpx-bank-element-loader"
+    >
+      <slot name="loading">
+        <div class="vue-stripe-loading-message">
+          Loading FPX bank selector...
+        </div>
+      </slot>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.vue-stripe-fpx-bank-element {
+  position: relative;
+}
+
+.vue-stripe-fpx-bank-element-mount {
+  padding: 12px;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  background-color: white;
+  transition: all 0.3s ease;
+  min-height: 44px;
+}
+
+.vue-stripe-fpx-bank-element-mount:focus-within {
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.vue-stripe-fpx-bank-element-loading {
+  opacity: 0.5;
+}
+
+.vue-stripe-fpx-bank-element-error {
+  color: #dc3545;
+  padding: 0.5rem 0;
+  font-size: 0.875rem;
+}
+
+.vue-stripe-fpx-bank-element-loader {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: #6c757d;
+  text-align: center;
+}
+
+.vue-stripe-error-message,
+.vue-stripe-loading-message {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+</style>

--- a/packages/vue-stripe/src/components/index.ts
+++ b/packages/vue-stripe/src/components/index.ts
@@ -30,3 +30,7 @@ export { default as VueStripeCheckout } from './VueStripeCheckout.vue'
 
 // Pricing Table (v5.3.0)
 export { default as VueStripePricingTable } from './VueStripePricingTable.vue'
+
+// APAC Regional Elements (v5.4.0)
+export { default as VueStripeFpxBankElement } from './VueStripeFpxBankElement.vue'
+export { default as VueStripeAuBankAccountElement } from './VueStripeAuBankAccountElement.vue'

--- a/packages/vue-stripe/tests/components/VueStripeAuBankAccountElement.test.ts
+++ b/packages/vue-stripe/tests/components/VueStripeAuBankAccountElement.test.ts
@@ -1,0 +1,337 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { h, nextTick } from 'vue-demi'
+import VueStripeAuBankAccountElement from '../../src/components/VueStripeAuBankAccountElement.vue'
+import VueStripeElements from '../../src/components/VueStripeElements.vue'
+import VueStripeProvider from '../../src/components/VueStripeProvider.vue'
+import { flushPromises, createMockElement } from '../setup'
+
+describe('VueStripeAuBankAccountElement', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // Helper to mount with full provider hierarchy
+  const mountWithProviders = async (auBankProps = {}, auBankSlots = {}) => {
+    const wrapper = mount(VueStripeProvider, {
+      props: {
+        publishableKey: 'pk_test_123'
+      },
+      slots: {
+        default: () => h(VueStripeElements, {}, {
+          default: () => h(VueStripeAuBankAccountElement, auBankProps, auBankSlots)
+        })
+      }
+    })
+
+    await flushPromises()
+    await wrapper.vm.$nextTick()
+
+    return wrapper
+  }
+
+  it('should throw error when used outside StripeElements', () => {
+    expect(() => {
+      mount(VueStripeAuBankAccountElement, {
+        props: {}
+      })
+    }).toThrow('VueStripeAuBankAccountElement must be used within VueStripeElements')
+  })
+
+  it('should render AU Bank Account element container', async () => {
+    const wrapper = await mountWithProviders()
+
+    expect(wrapper.find('.vue-stripe-au-bank-account-element').exists()).toBe(true)
+    expect(wrapper.find('.vue-stripe-au-bank-account-element-mount').exists()).toBe(true)
+  })
+
+  it('should mount Stripe AU Bank Account element on the DOM', async () => {
+    const mockElement = createMockElement()
+    const mockCreate = vi.fn(() => mockElement)
+
+    const mockLoadStripe = vi.mocked(await import('@stripe/stripe-js')).loadStripe
+    mockLoadStripe.mockResolvedValueOnce({
+      elements: vi.fn(() => ({
+        create: mockCreate
+      })),
+      confirmPayment: vi.fn(),
+      confirmCardSetup: vi.fn(),
+      registerAppInfo: vi.fn()
+    } as any)
+
+    await mountWithProviders()
+
+    expect(mockCreate).toHaveBeenCalledWith('auBankAccount', undefined)
+    expect(mockElement.mount).toHaveBeenCalled()
+  })
+
+  it('should pass options to AU Bank Account element', async () => {
+    const mockElement = createMockElement()
+    const mockCreate = vi.fn(() => mockElement)
+
+    const mockLoadStripe = vi.mocked(await import('@stripe/stripe-js')).loadStripe
+    mockLoadStripe.mockResolvedValueOnce({
+      elements: vi.fn(() => ({
+        create: mockCreate
+      })),
+      confirmPayment: vi.fn(),
+      confirmCardSetup: vi.fn(),
+      registerAppInfo: vi.fn()
+    } as any)
+
+    const auBankOptions = {
+      style: {
+        base: {
+          fontSize: '16px',
+          color: '#424770'
+        }
+      },
+      iconStyle: 'solid' as const,
+      hideIcon: false
+    }
+
+    await mountWithProviders({
+      options: auBankOptions
+    })
+
+    expect(mockCreate).toHaveBeenCalledWith('auBankAccount', auBankOptions)
+  })
+
+  it('should set up event listeners on AU Bank Account element', async () => {
+    const mockElement = createMockElement()
+    const mockCreate = vi.fn(() => mockElement)
+
+    const mockLoadStripe = vi.mocked(await import('@stripe/stripe-js')).loadStripe
+    mockLoadStripe.mockResolvedValueOnce({
+      elements: vi.fn(() => ({
+        create: mockCreate
+      })),
+      confirmPayment: vi.fn(),
+      confirmCardSetup: vi.fn(),
+      registerAppInfo: vi.fn()
+    } as any)
+
+    await mountWithProviders()
+
+    expect(mockElement.on).toHaveBeenCalledWith('ready', expect.any(Function))
+    expect(mockElement.on).toHaveBeenCalledWith('change', expect.any(Function))
+    expect(mockElement.on).toHaveBeenCalledWith('focus', expect.any(Function))
+    expect(mockElement.on).toHaveBeenCalledWith('blur', expect.any(Function))
+    expect(mockElement.on).toHaveBeenCalledWith('escape', expect.any(Function))
+  })
+
+  it('should emit ready event when AU Bank Account element is ready', async () => {
+    let readyCallback: Function | null = null
+    const mockElement = {
+      ...createMockElement(),
+      on: vi.fn((event: string, callback: Function) => {
+        if (event === 'ready') {
+          readyCallback = callback
+        }
+      })
+    }
+
+    const mockLoadStripe = vi.mocked(await import('@stripe/stripe-js')).loadStripe
+    mockLoadStripe.mockResolvedValueOnce({
+      elements: vi.fn(() => ({
+        create: vi.fn(() => mockElement)
+      })),
+      confirmPayment: vi.fn(),
+      confirmCardSetup: vi.fn(),
+      registerAppInfo: vi.fn()
+    } as any)
+
+    const wrapper = await mountWithProviders()
+
+    if (readyCallback) {
+      readyCallback()
+    }
+
+    await nextTick()
+
+    const auBankComponent = wrapper.findComponent(VueStripeAuBankAccountElement)
+    const emitted = auBankComponent.emitted('ready')
+    expect(emitted).toBeTruthy()
+  })
+
+  it('should emit change event with BSB and account data', async () => {
+    let changeCallback: Function | null = null
+    const mockElement = {
+      ...createMockElement(),
+      on: vi.fn((event: string, callback: Function) => {
+        if (event === 'change') {
+          changeCallback = callback
+        }
+      })
+    }
+
+    const mockLoadStripe = vi.mocked(await import('@stripe/stripe-js')).loadStripe
+    mockLoadStripe.mockResolvedValueOnce({
+      elements: vi.fn(() => ({
+        create: vi.fn(() => mockElement)
+      })),
+      confirmPayment: vi.fn(),
+      confirmCardSetup: vi.fn(),
+      registerAppInfo: vi.fn()
+    } as any)
+
+    const wrapper = await mountWithProviders()
+
+    const changeEvent = {
+      complete: true,
+      empty: false,
+      bankName: 'Commonwealth Bank of Australia',
+      branchName: 'Sydney Branch',
+      error: undefined
+    }
+
+    if (changeCallback) {
+      changeCallback(changeEvent)
+    }
+
+    await nextTick()
+
+    const auBankComponent = wrapper.findComponent(VueStripeAuBankAccountElement)
+    const emitted = auBankComponent.emitted('change')
+    expect(emitted).toBeTruthy()
+    expect(emitted![0][0]).toEqual(changeEvent)
+  })
+
+  it('should update error state from change event', async () => {
+    let changeCallback: Function | null = null
+    const mockElement = {
+      ...createMockElement(),
+      on: vi.fn((event: string, callback: Function) => {
+        if (event === 'change') {
+          changeCallback = callback
+        }
+      })
+    }
+
+    const mockLoadStripe = vi.mocked(await import('@stripe/stripe-js')).loadStripe
+    mockLoadStripe.mockResolvedValueOnce({
+      elements: vi.fn(() => ({
+        create: vi.fn(() => mockElement)
+      })),
+      confirmPayment: vi.fn(),
+      confirmCardSetup: vi.fn(),
+      registerAppInfo: vi.fn()
+    } as any)
+
+    const wrapper = await mountWithProviders()
+
+    const changeEvent = {
+      complete: false,
+      empty: false,
+      error: {
+        message: 'Invalid BSB number.'
+      }
+    }
+
+    if (changeCallback) {
+      changeCallback(changeEvent)
+    }
+
+    await nextTick()
+
+    expect(wrapper.find('.vue-stripe-au-bank-account-element-error').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Invalid BSB number.')
+  })
+
+  it('should destroy element on unmount', async () => {
+    const mockElement = createMockElement()
+    const mockCreate = vi.fn(() => mockElement)
+
+    const mockLoadStripe = vi.mocked(await import('@stripe/stripe-js')).loadStripe
+    mockLoadStripe.mockResolvedValueOnce({
+      elements: vi.fn(() => ({
+        create: mockCreate
+      })),
+      confirmPayment: vi.fn(),
+      confirmCardSetup: vi.fn(),
+      registerAppInfo: vi.fn()
+    } as any)
+
+    const wrapper = await mountWithProviders()
+
+    wrapper.unmount()
+
+    expect(mockElement.destroy).toHaveBeenCalled()
+  })
+
+  it('should expose element methods via defineExpose', async () => {
+    const mockElement = createMockElement()
+    const mockCreate = vi.fn(() => mockElement)
+
+    const mockLoadStripe = vi.mocked(await import('@stripe/stripe-js')).loadStripe
+    mockLoadStripe.mockResolvedValueOnce({
+      elements: vi.fn(() => ({
+        create: mockCreate
+      })),
+      confirmPayment: vi.fn(),
+      confirmCardSetup: vi.fn(),
+      registerAppInfo: vi.fn()
+    } as any)
+
+    const wrapper = await mountWithProviders()
+
+    const auBankComponent = wrapper.findComponent(VueStripeAuBankAccountElement)
+
+    expect(auBankComponent.vm).toBeDefined()
+
+    const vm = auBankComponent.vm as any
+    expect(typeof vm.focus === 'function' || vm.focus === undefined || vm.focus).toBeTruthy()
+    expect(typeof vm.blur === 'function' || vm.blur === undefined || vm.blur).toBeTruthy()
+    expect(typeof vm.clear === 'function' || vm.clear === undefined || vm.clear).toBeTruthy()
+  })
+
+  it('should handle iconStyle option', async () => {
+    const mockElement = createMockElement()
+    const mockCreate = vi.fn(() => mockElement)
+
+    const mockLoadStripe = vi.mocked(await import('@stripe/stripe-js')).loadStripe
+    mockLoadStripe.mockResolvedValueOnce({
+      elements: vi.fn(() => ({
+        create: mockCreate
+      })),
+      confirmPayment: vi.fn(),
+      confirmCardSetup: vi.fn(),
+      registerAppInfo: vi.fn()
+    } as any)
+
+    await mountWithProviders({
+      options: {
+        iconStyle: 'solid'
+      }
+    })
+
+    expect(mockCreate).toHaveBeenCalledWith('auBankAccount', expect.objectContaining({
+      iconStyle: 'solid'
+    }))
+  })
+
+  it('should handle hideIcon option', async () => {
+    const mockElement = createMockElement()
+    const mockCreate = vi.fn(() => mockElement)
+
+    const mockLoadStripe = vi.mocked(await import('@stripe/stripe-js')).loadStripe
+    mockLoadStripe.mockResolvedValueOnce({
+      elements: vi.fn(() => ({
+        create: mockCreate
+      })),
+      confirmPayment: vi.fn(),
+      confirmCardSetup: vi.fn(),
+      registerAppInfo: vi.fn()
+    } as any)
+
+    await mountWithProviders({
+      options: {
+        hideIcon: true
+      }
+    })
+
+    expect(mockCreate).toHaveBeenCalledWith('auBankAccount', expect.objectContaining({
+      hideIcon: true
+    }))
+  })
+})

--- a/packages/vue-stripe/tests/components/VueStripeFpxBankElement.test.ts
+++ b/packages/vue-stripe/tests/components/VueStripeFpxBankElement.test.ts
@@ -1,0 +1,314 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { h, nextTick } from 'vue-demi'
+import VueStripeFpxBankElement from '../../src/components/VueStripeFpxBankElement.vue'
+import VueStripeElements from '../../src/components/VueStripeElements.vue'
+import VueStripeProvider from '../../src/components/VueStripeProvider.vue'
+import { flushPromises, createMockElement } from '../setup'
+
+describe('VueStripeFpxBankElement', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // Helper to mount with full provider hierarchy
+  const mountWithProviders = async (fpxProps = {}, fpxSlots = {}) => {
+    const wrapper = mount(VueStripeProvider, {
+      props: {
+        publishableKey: 'pk_test_123'
+      },
+      slots: {
+        default: () => h(VueStripeElements, {}, {
+          default: () => h(VueStripeFpxBankElement, fpxProps, fpxSlots)
+        })
+      }
+    })
+
+    await flushPromises()
+    await wrapper.vm.$nextTick()
+
+    return wrapper
+  }
+
+  it('should throw error when used outside StripeElements', () => {
+    expect(() => {
+      mount(VueStripeFpxBankElement, {
+        props: {}
+      })
+    }).toThrow('VueStripeFpxBankElement must be used within VueStripeElements')
+  })
+
+  it('should render FPX bank element container', async () => {
+    const wrapper = await mountWithProviders()
+
+    expect(wrapper.find('.vue-stripe-fpx-bank-element').exists()).toBe(true)
+    expect(wrapper.find('.vue-stripe-fpx-bank-element-mount').exists()).toBe(true)
+  })
+
+  it('should mount Stripe FPX bank element on the DOM with default accountHolderType', async () => {
+    const mockElement = createMockElement()
+    const mockCreate = vi.fn(() => mockElement)
+
+    const mockLoadStripe = vi.mocked(await import('@stripe/stripe-js')).loadStripe
+    mockLoadStripe.mockResolvedValueOnce({
+      elements: vi.fn(() => ({
+        create: mockCreate
+      })),
+      confirmPayment: vi.fn(),
+      confirmCardSetup: vi.fn(),
+      registerAppInfo: vi.fn()
+    } as any)
+
+    await mountWithProviders()
+
+    // FPX requires accountHolderType, default is 'individual'
+    expect(mockCreate).toHaveBeenCalledWith('fpxBank', expect.objectContaining({
+      accountHolderType: 'individual'
+    }))
+    expect(mockElement.mount).toHaveBeenCalled()
+  })
+
+  it('should pass accountHolderType prop to FPX element', async () => {
+    const mockElement = createMockElement()
+    const mockCreate = vi.fn(() => mockElement)
+
+    const mockLoadStripe = vi.mocked(await import('@stripe/stripe-js')).loadStripe
+    mockLoadStripe.mockResolvedValueOnce({
+      elements: vi.fn(() => ({
+        create: mockCreate
+      })),
+      confirmPayment: vi.fn(),
+      confirmCardSetup: vi.fn(),
+      registerAppInfo: vi.fn()
+    } as any)
+
+    await mountWithProviders({
+      accountHolderType: 'company'
+    })
+
+    expect(mockCreate).toHaveBeenCalledWith('fpxBank', expect.objectContaining({
+      accountHolderType: 'company'
+    }))
+  })
+
+  it('should pass options to FPX bank element', async () => {
+    const mockElement = createMockElement()
+    const mockCreate = vi.fn(() => mockElement)
+
+    const mockLoadStripe = vi.mocked(await import('@stripe/stripe-js')).loadStripe
+    mockLoadStripe.mockResolvedValueOnce({
+      elements: vi.fn(() => ({
+        create: mockCreate
+      })),
+      confirmPayment: vi.fn(),
+      confirmCardSetup: vi.fn(),
+      registerAppInfo: vi.fn()
+    } as any)
+
+    const fpxOptions = {
+      style: {
+        base: {
+          fontSize: '16px',
+          color: '#424770'
+        }
+      }
+    }
+
+    await mountWithProviders({
+      accountHolderType: 'individual',
+      options: fpxOptions
+    })
+
+    expect(mockCreate).toHaveBeenCalledWith('fpxBank', expect.objectContaining({
+      ...fpxOptions,
+      accountHolderType: 'individual'
+    }))
+  })
+
+  it('should set up event listeners on FPX bank element', async () => {
+    const mockElement = createMockElement()
+    const mockCreate = vi.fn(() => mockElement)
+
+    const mockLoadStripe = vi.mocked(await import('@stripe/stripe-js')).loadStripe
+    mockLoadStripe.mockResolvedValueOnce({
+      elements: vi.fn(() => ({
+        create: mockCreate
+      })),
+      confirmPayment: vi.fn(),
+      confirmCardSetup: vi.fn(),
+      registerAppInfo: vi.fn()
+    } as any)
+
+    await mountWithProviders()
+
+    expect(mockElement.on).toHaveBeenCalledWith('ready', expect.any(Function))
+    expect(mockElement.on).toHaveBeenCalledWith('change', expect.any(Function))
+    expect(mockElement.on).toHaveBeenCalledWith('focus', expect.any(Function))
+    expect(mockElement.on).toHaveBeenCalledWith('blur', expect.any(Function))
+    expect(mockElement.on).toHaveBeenCalledWith('escape', expect.any(Function))
+  })
+
+  it('should emit ready event when FPX bank element is ready', async () => {
+    let readyCallback: Function | null = null
+    const mockElement = {
+      ...createMockElement(),
+      on: vi.fn((event: string, callback: Function) => {
+        if (event === 'ready') {
+          readyCallback = callback
+        }
+      })
+    }
+
+    const mockLoadStripe = vi.mocked(await import('@stripe/stripe-js')).loadStripe
+    mockLoadStripe.mockResolvedValueOnce({
+      elements: vi.fn(() => ({
+        create: vi.fn(() => mockElement)
+      })),
+      confirmPayment: vi.fn(),
+      confirmCardSetup: vi.fn(),
+      registerAppInfo: vi.fn()
+    } as any)
+
+    const wrapper = await mountWithProviders()
+
+    if (readyCallback) {
+      readyCallback()
+    }
+
+    await nextTick()
+
+    const fpxComponent = wrapper.findComponent(VueStripeFpxBankElement)
+    const emitted = fpxComponent.emitted('ready')
+    expect(emitted).toBeTruthy()
+  })
+
+  it('should emit change event with bank selection data', async () => {
+    let changeCallback: Function | null = null
+    const mockElement = {
+      ...createMockElement(),
+      on: vi.fn((event: string, callback: Function) => {
+        if (event === 'change') {
+          changeCallback = callback
+        }
+      })
+    }
+
+    const mockLoadStripe = vi.mocked(await import('@stripe/stripe-js')).loadStripe
+    mockLoadStripe.mockResolvedValueOnce({
+      elements: vi.fn(() => ({
+        create: vi.fn(() => mockElement)
+      })),
+      confirmPayment: vi.fn(),
+      confirmCardSetup: vi.fn(),
+      registerAppInfo: vi.fn()
+    } as any)
+
+    const wrapper = await mountWithProviders()
+
+    const changeEvent = {
+      complete: true,
+      empty: false,
+      value: 'affin_bank',
+      error: undefined
+    }
+
+    if (changeCallback) {
+      changeCallback(changeEvent)
+    }
+
+    await nextTick()
+
+    const fpxComponent = wrapper.findComponent(VueStripeFpxBankElement)
+    const emitted = fpxComponent.emitted('change')
+    expect(emitted).toBeTruthy()
+    expect(emitted![0][0]).toEqual(changeEvent)
+  })
+
+  it('should update error state from change event', async () => {
+    let changeCallback: Function | null = null
+    const mockElement = {
+      ...createMockElement(),
+      on: vi.fn((event: string, callback: Function) => {
+        if (event === 'change') {
+          changeCallback = callback
+        }
+      })
+    }
+
+    const mockLoadStripe = vi.mocked(await import('@stripe/stripe-js')).loadStripe
+    mockLoadStripe.mockResolvedValueOnce({
+      elements: vi.fn(() => ({
+        create: vi.fn(() => mockElement)
+      })),
+      confirmPayment: vi.fn(),
+      confirmCardSetup: vi.fn(),
+      registerAppInfo: vi.fn()
+    } as any)
+
+    const wrapper = await mountWithProviders()
+
+    const changeEvent = {
+      complete: false,
+      empty: false,
+      error: {
+        message: 'Please select a bank.'
+      }
+    }
+
+    if (changeCallback) {
+      changeCallback(changeEvent)
+    }
+
+    await nextTick()
+
+    expect(wrapper.find('.vue-stripe-fpx-bank-element-error').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Please select a bank.')
+  })
+
+  it('should destroy element on unmount', async () => {
+    const mockElement = createMockElement()
+    const mockCreate = vi.fn(() => mockElement)
+
+    const mockLoadStripe = vi.mocked(await import('@stripe/stripe-js')).loadStripe
+    mockLoadStripe.mockResolvedValueOnce({
+      elements: vi.fn(() => ({
+        create: mockCreate
+      })),
+      confirmPayment: vi.fn(),
+      confirmCardSetup: vi.fn(),
+      registerAppInfo: vi.fn()
+    } as any)
+
+    const wrapper = await mountWithProviders()
+
+    wrapper.unmount()
+
+    expect(mockElement.destroy).toHaveBeenCalled()
+  })
+
+  it('should expose element methods via defineExpose', async () => {
+    const mockElement = createMockElement()
+    const mockCreate = vi.fn(() => mockElement)
+
+    const mockLoadStripe = vi.mocked(await import('@stripe/stripe-js')).loadStripe
+    mockLoadStripe.mockResolvedValueOnce({
+      elements: vi.fn(() => ({
+        create: mockCreate
+      })),
+      confirmPayment: vi.fn(),
+      confirmCardSetup: vi.fn(),
+      registerAppInfo: vi.fn()
+    } as any)
+
+    const wrapper = await mountWithProviders()
+
+    const fpxComponent = wrapper.findComponent(VueStripeFpxBankElement)
+
+    expect(fpxComponent.vm).toBeDefined()
+
+    const vm = fpxComponent.vm as any
+    expect(typeof vm.focus === 'function' || vm.focus === undefined || vm.focus).toBeTruthy()
+    expect(typeof vm.blur === 'function' || vm.blur === undefined || vm.blur).toBeTruthy()
+    expect(typeof vm.clear === 'function' || vm.clear === undefined || vm.clear).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary

Recovers previously-**stashed** work for two APAC regional Stripe elements the library still lacks, rebased from its original v5.3.0 base onto the current `docs/live-demo-examples` branch:

- **`VueStripeAuBankAccountElement`** — BECS Direct Debit (Australia)
- **`VueStripeFpxBankElement`** — FPX online banking (Malaysia)

The work had only ever existed in a local git stash and was at risk of being lost. This PR brings it back as reviewable code aligned with current progress.

## What's included (25 files, ~5,249 insertions)

- **Library:** `VueStripeAuBankAccountElement.vue`, `VueStripeFpxBankElement.vue` + exports in `components/index.ts`
- **Tests:** 23 tests, **all passing** (`pnpm vitest run` on both new files)
- **Docs:** API reference + guide pages for both, live-demo pages (`fpx-payment`, `becs-payment`), interactive example components, VitePress nav
- **Backend:** `/api/fpx-intent` + `/api/becs-intent` routes, demo pages, sidebar entries
- **Playground:** `FpxBankElementView`, `AuBankAccountElementView` + router/App registration

## Rebase / conflict resolution notes

Applied onto current `docs/live-demo-examples` (111 commits ahead of `master`). Most shared files auto-merged. Two required manual resolution — both **purely additive**, keeping both sides:

- `theme/composables/useBackendApi.ts` — kept the new `createSepaIntent/createEpsIntent/createP24Intent` regional helpers **and** added `createFpxIntent`/`createBecsIntent`
- `theme/index.ts` — kept all newer example registrations **and** added the FPX/BECS examples

## Validation done

- ✅ `VueStripeAuBankAccountElement.test.ts` + `VueStripeFpxBankElement.test.ts` → 23/23 pass
- ⚠️ Not yet run: full `pnpm build`, `pnpm typecheck`, lint, Vue 2 compat, and live backend/docs/playground smoke tests — see the linked review issue.

## Review focus

This is opened as a **draft** pending the alignment review tracked in the companion issue (patterns may have drifted since v5.3.0 — element factory usage, event/prop conventions, appearance API, new shared composables).

Recovered from stash; supersedes #441.
