### PR TITLE
chore(coverage): plan FPX + AU Bank Account elements

### DIFF
--- a/apps/docs/.vitepress/theme/data/stripe-coverage.ts
+++ b/apps/docs/.vitepress/theme/data/stripe-coverage.ts
@@ -65,8 +65,8 @@ export const coverage: CoverageCategory[] = [
       { name: 'iDEAL Bank', api: "create('idealBank')", status: 'covered', artifact: 'VueStripeIdealBankElement' },
       { name: 'P24 Bank', api: "create('p24Bank')", status: 'covered', artifact: 'VueStripeP24BankElement' },
       { name: 'EPS Bank', api: "create('epsBank')", status: 'covered', artifact: 'VueStripeEpsBankElement' },
-      { name: 'FPX Bank', api: "create('fpxBank')", status: 'accessible' },
-      { name: 'AU Bank Account', api: "create('auBankAccount')", status: 'accessible' }
+      { name: 'FPX Bank', api: "create('fpxBank')", status: 'planned', issue: 442 },
+      { name: 'AU Bank Account', api: "create('auBankAccount')", status: 'planned', issue: 442 }
     ]
   },
   {


### PR DESCRIPTION
## Summary

Marks the two APAC regional elements as **`planned`** in the Stripe coverage matrix (`apps/docs/.vitepress/theme/data/stripe-coverage.ts`) — the repo's documented single source of truth for what ships and what's next:

- **FPX Bank** (`create('fpxBank')`): `accessible` → `planned`, linked to #442
- **AU Bank Account** (`create('auBankAccount')`): `accessible` → `planned`, linked to #442

## Why

Implementation for both exists as draft PR #442 (recovered from a stash, review/alignment tracked in #443). Putting them on the roadmap as `planned` surfaces them as upcoming **next items** so they get factored into planning and prioritization rather than sitting only as `accessible` (reachable via the raw `elements` instance, no wrapper).

When #442 merges, these flip to `covered` with their `artifact` names (`VueStripeFpxBankElement`, `VueStripeAuBankAccountElement`).

## Validation

- ✅ `coverage-matrix.test.ts` passes — `planned` entries carry an `issue` and no `artifact`, per the guard.

## Links

- Implementation: #442
- Review & alignment: #443
